### PR TITLE
Export hyprland::RuleInstance so its available to crate users

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ pub use variables::VariableManager;
 
 // Feature-gated exports
 #[cfg(feature = "hyprland")]
-pub use hyprland::Hyprland;
+pub use hyprland::{Hyprland, RuleInstance};
 
 #[cfg(feature = "mutation")]
 pub use document::{ConfigDocument, DocumentNode, NodeLocation, NodeType};


### PR DESCRIPTION
## Info
Right now `lib.rs` doesn't re-export `RuleInstance` so its inaccessible to anyone using this crate and makes dealing with window and layer rule data difficult. This PR just adds the re-export.