### PR TITLE
feat: add hyprlang 068 parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cast"
@@ -61,9 +61,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.51"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -104,18 +104,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cpufeatures"
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d883447757bb0ee46f233e9dc22eb84d93a9508c9b868687b274fc431d886bf"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
  "alloca",
  "anes",
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed943f81ea2faa8dcecbbfa50164acf95d555afec96a27871663b300e387b2e4"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -204,9 +204,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -230,15 +230,15 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "hyprlang"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "pest",
@@ -275,15 +275,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -291,15 +291,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "num-traits"
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.8.4"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbcfd20a6d4eeba40179f05735784ad32bdaef05ce8e8af05f180d45bb3e7e22"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "serde",
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.4"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f72981ade67b1ca6adc26ec221be9f463f2b5839c7508998daa17c23d94d7f"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
 dependencies = [
  "pest",
  "pest_generator",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.4"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee9efd8cdb50d719a80088b76f81aec7c41ed6d522ee750178f83883d271625"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
 dependencies = [
  "pest",
  "pest_meta",
@@ -369,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.4"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf1d70880e76bdc13ba52eafa6239ce793d85c8e43896507e43dd8984ff05b82"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
@@ -407,18 +407,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -468,21 +468,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -525,15 +519,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -555,9 +549,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -588,9 +582,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "version_check"
@@ -610,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -623,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -633,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -646,18 +640,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -711,20 +705,26 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "96e13bc581734df6250836c59a5f44f3c57db9f9acb9dc8e3eaabdaf6170254d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "3545ea9e86d12ab9bba9fcd99b54c1556fd3199007def5a03c375623d05fac1c"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyprlang"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 authors = ["Alex Spinu"]
 description = "A scripting language interpreter and parser for Hyprlang and Hyprland configuration files."
@@ -17,15 +17,15 @@ hyprland = []
 mutation = []
 
 [dependencies]
-pest = { version = "2.8.4", features = ["pretty-print"] }
-pest_derive = "2.8.4"
+pest = { version = "2.8.6", features = ["pretty-print"] }
+pest_derive = "2.8.6"
 
 [lib]
 name = "hyprlang"
 path = "src/lib.rs"
 
 [dev-dependencies]
-criterion = { version = "0.8.1", features = ["html_reports"] }
+criterion = { version = "0.8.2", features = ["html_reports"] }
 
 [[bench]]
 name = "parsing"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This project is not endorsed by or affiliated with the Hyprland project/HyprWM O
 Parity:
 - For Hyprland < 0.53.0, use hyprlang-rs v0.3.x
 - For Hyprland >= 0.53.0, use hyprlang-rs v0.4.x
+- For Hyprlang 0.6.8 parity, use hyprlang-rs v0.5.x
 
 ## Features
 
@@ -35,7 +36,9 @@ Parity:
 - 🔄 **Mutation & Serialization** - Modify config values and save back to files (optional)
 - 📁 **Multi-File Mutation Tracking** - Track and save changes to the correct source file when using `source` directives
 - 🎯 **Windowrule v3 / Layerrule v2** - Full support for new special category syntax with 85+ registered properties
-- ✅ **Fully Tested** - 207 tests covering all features
+- 🔀 **Comment Escaping** - `##` in values produces a literal `#` character
+- 🔁 **Dynamic Variable Propagation** - Dynamically updated variables automatically re-evaluate dependent lines
+- ✅ **Fully Tested** - 241 tests covering all features
 
 ## Benchmarks
 
@@ -51,7 +54,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-hyprlang = "0.4.1"
+hyprlang = "0.5.0"
 ```
 
 ### Optional Features
@@ -576,7 +579,7 @@ assert_eq!(anims.len(), 2);
 ### Special Categories
 
 ```rust
-use hyprlang::{Config, SpecialCategoryDescriptor};
+use hyprlang::{Config, ConfigValue, SpecialCategoryDescriptor};
 
 let mut config = Config::new();
 
@@ -584,6 +587,14 @@ let mut config = Config::new();
 config.register_special_category(
     SpecialCategoryDescriptor::keyed("device", "name")
 );
+config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
+config.register_special_category_value(
+    "device",
+    "accel_profile",
+    ConfigValue::String(String::new()),
+);
+config.register_special_category_value("device", "repeat_rate", ConfigValue::Int(0));
+config.register_special_category_value("device", "repeat_delay", ConfigValue::Int(0));
 
 config.parse(r#"
     device[mouse] {
@@ -945,6 +956,15 @@ options.allow_dynamic_parsing = true;
 // Base directory for resolving source directives
 options.base_dir = Some(PathBuf::from("/path/to/config"));
 
+// Parse without storing values (dry-run validation)
+options.verify_only = false;
+
+// Don't error on missing config file
+options.allow_missing_config = false;
+
+// Treat path argument as raw config content instead of a file path
+options.path_is_stream = false;
+
 let config = Config::with_options(options);
 ```
 
@@ -969,6 +989,7 @@ let config = Config::with_options(options);
 // Parsing
 config.parse(content: &str) -> Result<()>
 config.parse_file(path: &Path) -> Result<()>
+config.parse_dynamic(line: &str) -> Result<()>
 
 // Getting values
 config.get(key: &str) -> Result<&ConfigValue>
@@ -981,6 +1002,7 @@ config.get_color(key: &str) -> Result<Color>
 // Setting values
 config.set(key: impl Into<String>, value: ConfigValue)
 config.set_variable(name: String, value: String)
+config.change_root_path(path: &Path)
 
 // Mutation (requires `mutation` feature)
 config.set_int(key, value: i64)
@@ -1013,12 +1035,15 @@ config.has(key: &str) -> bool
 // Handlers
 config.register_handler_fn(keyword, handler_fn)
 config.register_category_handler_fn(category, keyword, handler_fn)
+config.unregister_handler(keyword: &str) -> bool
+config.unregister_category_handler(category: &str, keyword: &str) -> bool
 config.get_handler_calls(handler: &str) -> Option<&Vec<String>>
 config.all_handler_calls() -> &HashMap<String, Vec<String>>
 
 // Special categories
 config.register_special_category(descriptor)
 config.get_special_category(category: &str, key: &str) -> Result<HashMap<String, &ConfigValue>>
+config.special_category_exists_for_key(category: &str, key: &str) -> bool
 ```
 
 ## Examples
@@ -1090,16 +1115,18 @@ cargo test
 cargo test --all-features
 ```
 
-The project includes **177 tests** with 100% pass rate:
-- 52 unit tests covering core functionality
+The project includes **241 tests** with 100% pass rate:
+- 56 unit tests covering core functionality
 - 11 conditional directive tests
 - 11 expression escaping tests
-- 15 windowrule v3 / layerrule v2 tests
+- 21 windowrule v3 / layerrule v2 tests
 - 12 Hyprland config tests
+- 15 Hyprland parity tests
 - 10 mutation & round-trip serialization tests
 - 6 multi-file mutation tests
 - 19 parsing edge case tests
-- 41 documentation tests
+- 30 Hyprlang 0.6.8 parity tests
+- 50 documentation tests
 
 All tests from the original Hyprlang C++ implementation have been ported and pass successfully, plus additional tests for new features like expression escaping, negated conditionals, windowrule v3 syntax, and comprehensive edge case coverage.
 
@@ -1108,7 +1135,7 @@ All tests from the original Hyprlang C++ implementation have been ported and pas
 The parser is implemented using [pest](https://pest.rs/) with a PEG grammar. The grammar file is located at `src/hyprlang.pest`.
 
 Key syntax features:
-- Comments: `#` for single-line, `##` for documentation
+- Comments: `#` for single-line, `##` for literal `#` in values
 - Variables: `$VAR = value`, `$env:PATH` (environment variables)
 - Expressions: `{{expr}}` with arithmetic operators (+, -, *, /)
 - Expression escaping: `\{{}}` or `{\{}}` for literal braces

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,15 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
+/// A line that references a variable, tracked for dynamic variable propagation
+#[derive(Debug, Clone)]
+struct VariableLine {
+    /// The raw statement that references the variable
+    statement: Statement,
+    /// The category path at the time the statement was processed
+    category_path: Vec<String>,
+}
+
 /// Main configuration manager
 pub struct Config {
     /// Configuration values: category_path:key -> value
@@ -49,6 +58,14 @@ pub struct Config {
     /// Collected errors (when throw_all_errors is enabled)
     errors: Vec<ConfigError>,
 
+    /// Lines that reference each variable (for dynamic variable propagation)
+    variable_lines: HashMap<String, Vec<VariableLine>>,
+
+    /// Whether this parse context should record variable dependency lines.
+    ///
+    /// Upstream only records dependencies during non-dynamic parsing.
+    record_variable_lines: bool,
+
     /// Document structure (for full-fidelity serialization)
     #[cfg(feature = "mutation")]
     document: Option<crate::document::ConfigDocument>,
@@ -77,6 +94,15 @@ pub struct ConfigOptions {
 
     /// Base directory for resolving source directives
     pub base_dir: Option<PathBuf>,
+
+    /// Parse without setting values (dry-run validation)
+    pub verify_only: bool,
+
+    /// Don't error on missing config file
+    pub allow_missing_config: bool,
+
+    /// Treat path as raw config string instead of a file path
+    pub path_is_stream: bool,
 }
 
 impl Default for ConfigOptions {
@@ -85,6 +111,9 @@ impl Default for ConfigOptions {
             throw_all_errors: false,
             allow_dynamic_parsing: true,
             base_dir: None,
+            verify_only: false,
+            allow_missing_config: false,
+            path_is_stream: false,
         }
     }
 }
@@ -105,6 +134,8 @@ impl Config {
             options: ConfigOptions::default(),
             current_path: Vec::new(),
             errors: Vec::new(),
+            variable_lines: HashMap::new(),
+            record_variable_lines: true,
             #[cfg(feature = "mutation")]
             document: None,
             #[cfg(feature = "mutation")]
@@ -133,6 +164,8 @@ impl Config {
             options,
             current_path: Vec::new(),
             errors: Vec::new(),
+            variable_lines: HashMap::new(),
+            record_variable_lines: true,
             #[cfg(feature = "mutation")]
             document: None,
             #[cfg(feature = "mutation")]
@@ -146,23 +179,65 @@ impl Config {
 
     /// Initialize the configuration (called before parsing)
     pub fn commence(&mut self) -> ParseResult<()> {
-        // Reset state
         self.errors.clear();
         self.directives.reset();
+        self.current_path.clear();
         Ok(())
+    }
+
+    fn reset_top_level_state(&mut self) {
+        self.errors.clear();
+        self.directives.reset();
+        self.current_path.clear();
+        self.values.clear();
+        self.handler_calls.clear();
+        self.variables.clear();
+        self.variable_lines.clear();
+        self.record_variable_lines = true;
+        self.expressions = ExpressionEvaluator::new();
+        self.special_categories.reset_for_parse();
+
+        if let Some(resolver) = &mut self.source_resolver {
+            resolver.reset();
+        }
+
+        #[cfg(feature = "mutation")]
+        {
+            self.document = None;
+            self.source_file = None;
+            self.multi_document = None;
+            self.current_source_file = None;
+        }
     }
 
     /// Parse a configuration file
     pub fn parse_file(&mut self, path: impl AsRef<Path>) -> ParseResult<()> {
         let path = path.as_ref();
+
+        // If path_is_stream, treat the path string as raw config content
+        if self.options.path_is_stream {
+            let content = path.to_string_lossy().to_string();
+            return self.parse(&content);
+        }
+
+        self.reset_top_level_state();
+
+        // Check if file exists - handle allow_missing_config
+        if !path.exists() {
+            if self.options.allow_missing_config {
+                return Ok(());
+            }
+            return Err(ConfigError::io(
+                path.display().to_string(),
+                "file not found",
+            ));
+        }
+
         let canonical_path = path
             .canonicalize()
             .unwrap_or_else(|_| path.to_path_buf());
 
-        // Set base dir from file path if not already set
-        if self.options.base_dir.is_none()
-            && let Some(parent) = path.parent()
-        {
+        if let Some(parent) = path.parent() {
             self.options.base_dir = Some(parent.to_path_buf());
             self.source_resolver = Some(SourceResolver::new(parent));
         }
@@ -180,11 +255,11 @@ impl Config {
         }
 
         // Parse the file with path tracking
-        self.parse_file_internal(&canonical_path)
+        self.parse_file_internal(&canonical_path, true)
     }
 
     /// Internal method to parse a file with path tracking
-    fn parse_file_internal(&mut self, path: &Path) -> ParseResult<()> {
+    fn parse_file_internal(&mut self, path: &Path, top_level: bool) -> ParseResult<()> {
         let content = std::fs::read_to_string(path)
             .map_err(|e| ConfigError::io(path.display().to_string(), e.to_string()))?;
 
@@ -195,12 +270,22 @@ impl Config {
         }
 
         // Parse the content
-        self.parse_with_path(&content, Some(path))
+        self.parse_with_path(&content, Some(path), top_level)
     }
 
     /// Parse content with an associated file path
-    fn parse_with_path(&mut self, input: &str, source_path: Option<&Path>) -> ParseResult<()> {
-        self.commence()?;
+    fn parse_with_path(
+        &mut self,
+        input: &str,
+        _source_path: Option<&Path>,
+        top_level: bool,
+    ) -> ParseResult<()> {
+        if top_level {
+            self.commence()?;
+        }
+
+        #[cfg(feature = "mutation")]
+        let previous_source_file = self.current_source_file.clone();
 
         #[cfg(feature = "mutation")]
         let (parsed, mut document) = HyprlangParser::parse_with_document(input)?;
@@ -210,31 +295,48 @@ impl Config {
         #[cfg(feature = "mutation")]
         {
             // Set the source path on the document
-            if let Some(path) = source_path {
+            if let Some(path) = _source_path {
                 document.source_path = Some(path.to_path_buf());
             }
 
             // Store document in multi_document if available
-            if let (Some(multi_doc), Some(path)) = (&mut self.multi_document, source_path) {
+            if let (Some(multi_doc), Some(path)) = (&mut self.multi_document, _source_path) {
                 multi_doc.add_document(path.to_path_buf(), document.clone());
             }
 
             // Also keep backward-compatible single document
-            self.document = Some(document);
+            if top_level || _source_path.is_none() {
+                self.document = Some(document.clone());
+            }
         }
 
         for statement in parsed.statements {
             if let Err(e) = self.process_statement(&statement) {
-                if self.options.throw_all_errors {
+                if self.directives.should_suppress_errors() {
+                    continue;
+                } else if self.options.throw_all_errors {
                     self.errors.push(e);
                 } else {
+                    #[cfg(feature = "mutation")]
+                    {
+                        self.current_source_file = previous_source_file;
+                    }
                     return Err(e);
                 }
             }
         }
 
         if !self.errors.is_empty() {
+            #[cfg(feature = "mutation")]
+            {
+                self.current_source_file = previous_source_file;
+            }
             return Err(ConfigError::multiple(std::mem::take(&mut self.errors)));
+        }
+
+        #[cfg(feature = "mutation")]
+        {
+            self.current_source_file = previous_source_file;
         }
 
         Ok(())
@@ -242,22 +344,347 @@ impl Config {
 
     /// Parse a configuration string
     pub fn parse(&mut self, input: &str) -> ParseResult<()> {
-        self.parse_with_path(input, None)
+        self.reset_top_level_state();
+        self.parse_with_path(input, None, true)
     }
 
     /// Parse a single line dynamically (after initial parse)
+    ///
+    /// If a variable is being set, all lines that previously referenced that variable
+    /// will be re-evaluated with the new value (dynamic variable propagation).
+    ///
+    /// Supports bracket syntax for special categories: `special[key]:prop = value`
     pub fn parse_dynamic(&mut self, line: &str) -> ParseResult<()> {
         if !self.options.allow_dynamic_parsing {
             return Err(ConfigError::custom("Dynamic parsing is not enabled"));
         }
 
-        let parsed = HyprlangParser::parse_config(line)?;
-
-        for statement in parsed.statements {
-            self.process_statement(&statement)?;
+        // Handle special category bracket syntax: special[key]:prop = value
+        if let Some(result) = self.try_parse_dynamic_special_category(line)? {
+            return Ok(result);
         }
 
+        let parsed = HyprlangParser::parse_config(line)?;
+        let previous_recording = std::mem::replace(&mut self.record_variable_lines, false);
+
+        let result = (|| {
+            for statement in parsed.statements {
+                // Check if this is a variable definition - we'll need to propagate
+                let var_name = if let Statement::VariableDef { ref name, .. } = statement {
+                    Some(name.clone())
+                } else {
+                    None
+                };
+
+                self.process_statement(&statement)?;
+
+                // If a variable was set, re-evaluate all dependent lines
+                if let Some(name) = var_name {
+                    self.propagate_variable(&name)?;
+                }
+            }
+            Ok(())
+        })();
+
+        self.record_variable_lines = previous_recording;
+        result
+    }
+
+    /// Parse a dynamic assignment with separate key and value arguments.
+    ///
+    /// Equivalent to `parse_dynamic("key = value")`.
+    pub fn parse_dynamic_kv(&mut self, key: &str, value: &str) -> ParseResult<()> {
+        self.parse_dynamic(&format!("{} = {}", key, value))
+    }
+
+    /// Try to handle bracket syntax in dynamic parsing: `special[key]:prop = value`
+    fn try_parse_dynamic_special_category(&mut self, line: &str) -> ParseResult<Option<()>> {
+        // Look for pattern: name[key]:prop = value
+        let Some(bracket_start) = line.find('[') else {
+            return Ok(None);
+        };
+        let Some(bracket_end) = line[bracket_start..].find(']') else {
+            return Ok(None);
+        };
+        let bracket_end = bracket_start + bracket_end;
+
+        // Extract parts
+        let cat_name = line[..bracket_start].trim();
+        let instance_key = &line[bracket_start + 1..bracket_end];
+
+        let rest = &line[bracket_end + 1..];
+        if !rest.starts_with(':') {
+            return Ok(None);
+        }
+        let rest = &rest[1..]; // skip ':'
+
+        let Some(eq_pos) = rest.find('=') else {
+            return Ok(None);
+        };
+        let prop_name = rest[..eq_pos].trim();
+        let raw_value = rest[eq_pos + 1..].trim();
+
+        // Check if this is a registered special category
+        if !self.special_categories.is_registered(cat_name) {
+            return Ok(None);
+        }
+
+        let resolved_value = self.resolve_raw_string(raw_value, true)?;
+        let full_key = format!("{}[{}]:{}", cat_name, instance_key, prop_name);
+        let _ = self.store_special_assignment(
+            cat_name,
+            instance_key,
+            prop_name,
+            &resolved_value,
+            full_key,
+        )?;
+
+        Ok(Some(()))
+    }
+
+    /// Re-evaluate all lines that reference the given variable
+    fn propagate_variable(&mut self, var_name: &str) -> ParseResult<()> {
+        if let Some(lines) = self.variable_lines.get(var_name).cloned() {
+            let previous_recording = std::mem::replace(&mut self.record_variable_lines, false);
+            for var_line in &lines {
+                let saved_path =
+                    std::mem::replace(&mut self.current_path, var_line.category_path.clone());
+                let _ = self.process_statement(&var_line.statement);
+                self.current_path = saved_path;
+            }
+            self.record_variable_lines = previous_recording;
+        }
         Ok(())
+    }
+
+    /// Track which variables are referenced in a value string
+    fn track_variable_references(&mut self, value: &str, statement: &Statement) {
+        if !self.record_variable_lines {
+            return;
+        }
+
+        let var_line = VariableLine {
+            statement: statement.clone(),
+            category_path: self.current_path.clone(),
+        };
+
+        // Extract all variable names referenced in the value
+        let mut chars = value.chars().peekable();
+        while let Some(ch) = chars.next() {
+            if ch == '$' {
+                let mut name = String::new();
+                while let Some(&c) = chars.peek() {
+                    if c.is_alphanumeric() || c == '_' {
+                        name.push(c);
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+                if !name.is_empty() {
+                    self.variable_lines
+                        .entry(name)
+                        .or_default()
+                        .push(var_line.clone());
+                }
+            }
+        }
+    }
+
+    fn split_path_segment(segment: &str) -> (String, Option<String>) {
+        if let Some(start) = segment.find('[')
+            && segment.ends_with(']')
+            && start < segment.len() - 1
+        {
+            return (
+                segment[..start].to_string(),
+                Some(segment[start + 1..segment.len() - 1].to_string()),
+            );
+        }
+
+        (segment.to_string(), None)
+    }
+
+    fn plain_current_path(&self) -> Vec<String> {
+        self.current_path
+            .iter()
+            .map(|segment| Self::split_path_segment(segment).0)
+            .collect()
+    }
+
+    fn active_special_context(&self) -> Option<(String, String, Vec<String>)> {
+        let plain_path = self.plain_current_path();
+
+        for idx in (0..self.current_path.len()).rev() {
+            let (_, maybe_key) = Self::split_path_segment(&self.current_path[idx]);
+            let Some(instance_key) = maybe_key else {
+                continue;
+            };
+
+            let category_name = plain_path[..=idx].join(":");
+            if self.special_categories.is_registered(&category_name) {
+                return Some((category_name, instance_key, plain_path[idx + 1..].to_vec()));
+            }
+        }
+
+        None
+    }
+
+    fn resolve_special_assignment(
+        &mut self,
+        key: &[String],
+        resolved_value: &str,
+    ) -> ParseResult<Option<(String, String, String, String)>> {
+        if let Some((category_name, instance_key, nested_path)) = self.active_special_context() {
+            let mut property_segments = nested_path;
+            property_segments.extend(key.iter().cloned());
+            let property_name = property_segments.join(":");
+            let storage_key = format!("{}[{}]:{}", category_name, instance_key, property_name);
+            return Ok(Some((category_name, instance_key, property_name, storage_key)));
+        }
+
+        let plain_path = self.plain_current_path();
+        let mut combined_path = plain_path.clone();
+        combined_path.extend(key.iter().cloned());
+
+        let Some((category_name, prefix_len)) = self
+            .special_categories
+            .find_matching_category_segments(&combined_path)
+        else {
+            return Ok(None);
+        };
+
+        let descriptor = self
+            .special_categories
+            .get_descriptor(&category_name)
+            .cloned()
+            .ok_or_else(|| ConfigError::category_not_found(&category_name, None))?;
+        let property_segments = combined_path[prefix_len..].to_vec();
+        if property_segments.is_empty() {
+            return Ok(None);
+        }
+        let property_name = property_segments.join(":");
+
+        match descriptor.category_type {
+            crate::special_categories::SpecialCategoryType::Static => Ok(Some((
+                category_name.clone(),
+                "static".to_string(),
+                property_name.clone(),
+                format!("{}:{}", category_name, property_name),
+            ))),
+            crate::special_categories::SpecialCategoryType::Keyed => {
+                if plain_path.len() < prefix_len {
+                    return Ok(None);
+                }
+
+                let key_field = descriptor.key_field.clone().ok_or_else(|| {
+                    ConfigError::custom(format!(
+                        "Keyed category '{}' is missing its key field descriptor",
+                        category_name
+                    ))
+                })?;
+
+                let (_, existing_key) = Self::split_path_segment(&self.current_path[prefix_len - 1]);
+                let instance_key = if let Some(existing_key) = existing_key {
+                    existing_key
+                } else {
+                    if property_name != key_field {
+                        return Err(ConfigError::custom(format!(
+                            "special category's first value must be the key. Key for <{}> is <{}>",
+                            category_name, key_field
+                        )));
+                    }
+
+                    let instance_key = resolved_value.to_string();
+                    self.special_categories
+                        .create_instance(&category_name, Some(instance_key.clone()))?;
+                    self.current_path[prefix_len - 1] =
+                        format!("{}[{}]", plain_path[prefix_len - 1], instance_key);
+                    instance_key
+                };
+
+                Ok(Some((
+                    category_name.clone(),
+                    instance_key.clone(),
+                    property_name.clone(),
+                    format!("{}[{}]:{}", category_name, instance_key, property_name),
+                )))
+            }
+            crate::special_categories::SpecialCategoryType::Anonymous => {
+                if plain_path.len() < prefix_len {
+                    return Ok(None);
+                }
+
+                let (_, existing_key) = Self::split_path_segment(&self.current_path[prefix_len - 1]);
+                let instance_key = if let Some(existing_key) = existing_key {
+                    existing_key
+                } else {
+                    let instance_key = self.special_categories.create_instance(&category_name, None)?;
+                    self.current_path[prefix_len - 1] =
+                        format!("{}[{}]", plain_path[prefix_len - 1], instance_key);
+                    instance_key
+                };
+
+                Ok(Some((
+                    category_name.clone(),
+                    instance_key.clone(),
+                    property_name.clone(),
+                    format!("{}[{}]:{}", category_name, instance_key, property_name),
+                )))
+            }
+        }
+    }
+
+    fn store_special_assignment(
+        &mut self,
+        category_name: &str,
+        instance_key: &str,
+        property_name: &str,
+        resolved_value: &str,
+        storage_key: String,
+    ) -> ParseResult<bool> {
+        let descriptor = self
+            .special_categories
+            .get_descriptor(category_name)
+            .cloned()
+            .ok_or_else(|| ConfigError::category_not_found(category_name, None))?;
+
+        let config_value = if descriptor.key_field.as_deref() == Some(property_name) {
+            ConfigValue::String(resolved_value.to_string())
+        } else if let Some(default_value) = descriptor.default_values.get(property_name) {
+            self.parse_value_for_expected_type(resolved_value, default_value)?
+        } else if descriptor.ignore_missing {
+            return Ok(false);
+        } else {
+            return Err(ConfigError::custom(format!(
+                "config option <{}> does not exist.",
+                storage_key
+            )));
+        };
+
+        if !self.options.verify_only {
+            match descriptor.category_type {
+                crate::special_categories::SpecialCategoryType::Static => {
+                    self.special_categories.create_instance(category_name, None)?;
+                }
+                crate::special_categories::SpecialCategoryType::Keyed
+                | crate::special_categories::SpecialCategoryType::Anonymous => {
+                    self.special_categories
+                        .create_instance(category_name, Some(instance_key.to_string()))?;
+                }
+            }
+
+            let entry = ConfigValueEntry::new(config_value, resolved_value.to_string());
+            if let Ok(instance) = self
+                .special_categories
+                .get_instance_mut(category_name, instance_key)
+            {
+                instance.set(property_name.to_string(), entry.clone());
+            }
+            self.values.insert(storage_key, entry);
+        }
+
+        Ok(!self.options.verify_only)
     }
 
     fn process_statement(&mut self, statement: &Statement) -> ParseResult<()> {
@@ -280,10 +707,12 @@ impl Config {
 
         match statement {
             Statement::VariableDef { name, value } => {
-                // Process escapes first, then expand variables
-                // Don't evaluate expressions here - they'll be evaluated when the variable is used
-                let escaped = process_escapes(value);
-                let expanded = self.variables.expand(&escaped)?;
+                let expanded = self.resolve_raw_string_with_restore(value, true, false)?;
+
+                // Track which variables this definition references (for propagation)
+                if value.contains('$') {
+                    self.track_variable_references(value, statement);
+                }
 
                 // Track variable origin in multi_document
                 #[cfg(feature = "mutation")]
@@ -293,44 +722,65 @@ impl Config {
                     multi_doc.register_key(format!("${}", name), source_file.clone());
                 }
 
-                self.variables.set(name.clone(), expanded.clone());
+                if !self.options.verify_only {
+                    self.variables.set(name.clone(), expanded.clone());
 
-                // Update expression evaluator if it's a number
-                if let Ok(num) = ConfigValue::parse_int(&expanded) {
-                    self.expressions.set_variable(name.clone(), num);
+                    // Update expression evaluator if it's a number
+                    if let Ok(num) = ConfigValue::parse_int(&expanded) {
+                        self.expressions.set_variable(name.clone(), num);
+                    }
                 }
 
                 Ok(())
             }
 
             Statement::Assignment { key, value } => {
-                // Check if we're inside a special category block
-                // Special category paths contain brackets like "windowrule[test]"
-                let in_special_category = self.current_path.iter().any(|p| p.contains('['));
+                // Track variable references for dynamic propagation
+                let value_str = self.value_to_string(value);
+                if value_str.contains('$') {
+                    self.track_variable_references(&value_str, statement);
+                }
 
-                // Check if this is a potential handler call (single identifier and registered handler)
-                // But NOT if we're inside a special category (properties there should be assignments)
-                let is_potential_handler = key.len() == 1 && !in_special_category;
-                let keyword = &key[0];
+                let resolved_value = self.resolve_value_to_string(value)?;
 
-                if is_potential_handler && self.handlers.has_handler(&self.current_path, keyword) {
+                if let Some((category_name, instance_key, property_name, storage_key)) =
+                    self.resolve_special_assignment(key, &resolved_value)?
+                {
+                    let _stored = self.store_special_assignment(
+                        &category_name,
+                        &instance_key,
+                        &property_name,
+                        &resolved_value,
+                        storage_key.clone(),
+                    )?;
+
+                    #[cfg(feature = "mutation")]
+                    if _stored
+                        && let (Some(multi_doc), Some(source_file)) =
+                            (&mut self.multi_document, &self.current_source_file)
+                    {
+                        multi_doc.register_key(storage_key.clone(), source_file.clone());
+                    }
+                } else if key.len() == 1
+                    && let Some(resolved_handler) =
+                        self.handlers.resolve_invocation(&self.current_path, &key[0])
+                {
                     // Treat as handler call
-                    let expanded_value = match value {
-                        Value::String(s) => self.variables.expand(s)?,
-                        _ => self.value_to_string(value),
-                    };
-
                     // Create full key including category path for handler calls
                     let full_key = if self.current_path.is_empty() {
-                        keyword.clone()
+                        resolved_handler.handler_keyword.clone()
                     } else {
-                        format!("{}:{}", self.current_path.join(":"), keyword)
+                        format!(
+                            "{}:{}",
+                            self.current_path.join(":"),
+                            resolved_handler.handler_keyword
+                        )
                     };
 
                     self.handler_calls
                         .entry(full_key.clone())
                         .or_default()
-                        .push(expanded_value.clone());
+                        .push(resolved_value.clone());
 
                     // Track handler origin in multi_document
                     #[cfg(feature = "mutation")]
@@ -341,23 +791,26 @@ impl Config {
                     }
 
                     self.handlers
-                        .execute(&self.current_path, keyword, &expanded_value, None)?;
+                        .execute_resolved(&self.current_path, &resolved_handler, &resolved_value)?;
                 } else {
                     // Regular assignment
                     let full_key = self.make_full_key(key);
                     let config_value = self.parse_config_value(value)?;
-                    let raw = self.value_to_string(value);
 
-                    // Track key origin in multi_document
-                    #[cfg(feature = "mutation")]
-                    if let (Some(multi_doc), Some(source_file)) =
-                        (&mut self.multi_document, &self.current_source_file)
-                    {
-                        multi_doc.register_key(full_key.clone(), source_file.clone());
+                    if !self.options.verify_only {
+                        let raw = self.value_to_string(value);
+
+                        // Track key origin in multi_document
+                        #[cfg(feature = "mutation")]
+                        if let (Some(multi_doc), Some(source_file)) =
+                            (&mut self.multi_document, &self.current_source_file)
+                        {
+                            multi_doc.register_key(full_key.clone(), source_file.clone());
+                        }
+
+                        self.values
+                            .insert(full_key, ConfigValueEntry::new(config_value, raw));
                     }
-
-                    self.values
-                        .insert(full_key, ConfigValueEntry::new(config_value, raw));
                 }
 
                 Ok(())
@@ -386,31 +839,31 @@ impl Config {
                 key,
                 statements,
             } => {
-                // If category is not registered as special and has no key, treat as regular category
-                if !self.special_categories.is_registered(name) {
-                    if key.is_none() {
-                        // Fall back to regular category block behavior
-                        self.current_path.push(name.clone());
+                if key.is_none() {
+                    self.current_path.push(name.clone());
 
-                        for stmt in statements {
-                            if let Err(e) = self.process_statement(stmt) {
-                                if self.options.throw_all_errors {
-                                    self.errors.push(e);
-                                } else {
-                                    self.current_path.pop();
-                                    return Err(e);
-                                }
+                    for stmt in statements {
+                        if let Err(e) = self.process_statement(stmt) {
+                            if self.options.throw_all_errors {
+                                self.errors.push(e);
+                            } else {
+                                self.current_path.pop();
+                                return Err(e);
                             }
                         }
-
-                        self.current_path.pop();
-                        return Ok(());
                     }
+
+                    self.current_path.pop();
+                    return Ok(());
+                }
+
+                if !self.special_categories.is_registered(name) {
                     return Err(ConfigError::category_not_found(name, None));
                 }
 
-                // Create the instance with the provided key (or auto-generate if none)
-                let instance_key = self.special_categories.create_instance(name, key.clone())?;
+                let instance_key = self
+                    .special_categories
+                    .create_instance(name, key.clone())?;
 
                 self.current_path
                     .push(format!("{}[{}]", name, instance_key));
@@ -427,21 +880,6 @@ impl Config {
                     }
                 }
 
-                // Store values in the special category instance
-                let full_path = self.current_path.last().unwrap();
-                for (key, value) in &self.values {
-                    if key.starts_with(full_path) {
-                        let sub_key = key.strip_prefix(full_path).unwrap().trim_start_matches(':');
-
-                        if let Ok(instance) = self
-                            .special_categories
-                            .get_instance_mut(name, &instance_key)
-                        {
-                            instance.set(sub_key.to_string(), value.clone());
-                        }
-                    }
-                }
-
                 self.current_path.pop();
                 Ok(())
             }
@@ -451,7 +889,7 @@ impl Config {
                 flags,
                 value,
             } => {
-                let expanded_value = self.variables.expand(value)?;
+                let expanded_value = self.resolve_raw_string(value, true)?;
 
                 // Store the handler call value only if it's registered or at root level
                 let should_store = self.handlers.has_handler(&self.current_path, keyword)
@@ -501,7 +939,7 @@ impl Config {
                     .unwrap_or_else(|_| resolved.clone());
 
                 // Parse the sourced file using internal method (avoids re-initializing multi_document)
-                let result = self.parse_file_internal(&canonical_resolved);
+                let result = self.parse_file_internal(&canonical_resolved, false);
 
                 // End load
                 if let Some(resolver) = &mut self.source_resolver {
@@ -517,6 +955,102 @@ impl Config {
             } => {
                 self.directives
                     .process_directive(directive_type, args.as_deref(), &self.variables)
+            }
+        }
+    }
+
+    fn resolve_raw_string_with_restore(
+        &mut self,
+        raw: &str,
+        evaluate_expressions: bool,
+        restore_escaped: bool,
+    ) -> ParseResult<String> {
+        let escaped = process_escapes(raw);
+        let expanded = self.variables.expand(&escaped)?;
+        let with_exprs = if evaluate_expressions {
+            self.evaluate_expressions_in_string(&expanded)?
+        } else {
+            expanded
+        };
+
+        if restore_escaped {
+            Ok(restore_escaped_braces(&with_exprs))
+        } else {
+            Ok(with_exprs)
+        }
+    }
+
+    fn resolve_raw_string(&mut self, raw: &str, evaluate_expressions: bool) -> ParseResult<String> {
+        self.resolve_raw_string_with_restore(raw, evaluate_expressions, true)
+    }
+
+    fn resolve_value_to_string(&mut self, value: &Value) -> ParseResult<String> {
+        match value {
+            Value::Expression(expr) => Ok(self.expressions.evaluate(expr)?.to_string()),
+            Value::Variable(name) => self.variables.expand(&format!("${}", name)),
+            Value::Color(color) => Ok(color.to_string()),
+            Value::Vec2(vec) => Ok(vec.to_string()),
+            Value::Number(num) => Ok(num.clone()),
+            Value::Boolean(b) => Ok(if *b { "true" } else { "false" }.to_string()),
+            Value::String(s) => self.resolve_raw_string(s, true),
+            Value::Multiline(lines) => {
+                let joined = MultilineProcessor::join_lines(lines);
+                self.resolve_raw_string(&joined, true)
+            }
+        }
+    }
+
+    fn parse_int_value(&self, s: &str) -> ParseResult<ConfigValue> {
+        if let Ok(b) = ConfigValue::parse_bool(s) {
+            return Ok(ConfigValue::Int(if b { 1 } else { 0 }));
+        }
+
+        if s.starts_with("rgba(") && s.ends_with(')') {
+            return self
+                .parse_rgba_string(s)
+                .map(|color| ConfigValue::Int(color.to_argb() as i64));
+        }
+
+        if s.starts_with("rgb(") && s.ends_with(')') {
+            return self
+                .parse_rgb_string(s)
+                .map(|color| ConfigValue::Int(color.to_argb() as i64));
+        }
+
+        Ok(ConfigValue::Int(ConfigValue::parse_int(s)?))
+    }
+
+    fn parse_value_for_expected_type(
+        &mut self,
+        resolved_value: &str,
+        expected: &ConfigValue,
+    ) -> ParseResult<ConfigValue> {
+        match expected {
+            ConfigValue::Int(_) => self.parse_int_value(resolved_value),
+            ConfigValue::Float(_) => Ok(ConfigValue::Float(ConfigValue::parse_float(
+                resolved_value,
+            )?)),
+            ConfigValue::String(_) => Ok(ConfigValue::String(resolved_value.to_string())),
+            ConfigValue::Vec2(_) => Ok(ConfigValue::Vec2(self.parse_vec2_string(resolved_value)?)),
+            ConfigValue::Color(_) => {
+                if resolved_value.starts_with("rgba(") && resolved_value.ends_with(')') {
+                    return Ok(ConfigValue::Color(self.parse_rgba_string(resolved_value)?));
+                }
+                if resolved_value.starts_with("rgb(") && resolved_value.ends_with(')') {
+                    return Ok(ConfigValue::Color(self.parse_rgb_string(resolved_value)?));
+                }
+                Ok(ConfigValue::Color(Color::from_hex(resolved_value)?))
+            }
+            ConfigValue::Custom { type_name, .. } => {
+                let handler = self
+                    .custom_types
+                    .get(type_name)
+                    .ok_or_else(|| ConfigError::custom(format!("Unknown custom type '{}'", type_name)))?;
+                let value = handler.parse(resolved_value)?;
+                Ok(ConfigValue::Custom {
+                    type_name: type_name.clone(),
+                    value: Rc::from(value),
+                })
             }
         }
     }
@@ -552,26 +1086,13 @@ impl Config {
             Value::Boolean(b) => Ok(ConfigValue::Int(if *b { 1 } else { 0 })),
 
             Value::String(s) => {
-                // Process escapes first (converts escaped braces to placeholders)
-                let escaped = process_escapes(s);
-                // Expand variables
-                let expanded = self.variables.expand(&escaped)?;
-                // Evaluate expressions (placeholders won't be evaluated)
-                let with_exprs = self.evaluate_expressions_in_string(&expanded)?;
-                // Restore escaped braces from placeholders to literal {{}}
-                let final_value = restore_escaped_braces(&with_exprs);
-                self.parse_string_value(&final_value)
+                let resolved = self.resolve_raw_string(s, true)?;
+                self.parse_string_value(&resolved)
             }
 
             Value::Multiline(lines) => {
                 let joined = MultilineProcessor::join_lines(lines);
-                // Process escapes before variable expansion
-                let escaped = process_escapes(&joined);
-                let expanded = self.variables.expand(&escaped)?;
-                // Evaluate expressions
-                let with_exprs = self.evaluate_expressions_in_string(&expanded)?;
-                // Restore escaped braces
-                let final_value = restore_escaped_braces(&with_exprs);
+                let final_value = self.resolve_raw_string(&joined, true)?;
                 Ok(ConfigValue::String(final_value))
             }
         }
@@ -774,6 +1295,21 @@ impl Config {
         }
     }
 
+    /// Change the root path for resolving source directives.
+    ///
+    /// This updates the base directory used for resolving relative paths in
+    /// `source = path` directives. Useful when re-parsing from a different location.
+    pub fn change_root_path(&mut self, path: &Path) {
+        let base_dir = if path.is_dir() {
+            path.to_path_buf()
+        } else {
+            path.parent().unwrap_or(path).to_path_buf()
+        };
+
+        self.options.base_dir = Some(base_dir.clone());
+        self.source_resolver = Some(SourceResolver::new(base_dir));
+    }
+
     /// Get a configuration value
     pub fn get(&self, key: &str) -> ParseResult<&ConfigValue> {
         self.values
@@ -870,6 +1406,20 @@ impl Config {
             .register_global(keyword.clone(), FunctionHandler::new(keyword, handler));
     }
 
+    /// Unregister a previously registered handler by keyword.
+    ///
+    /// Returns `true` if the handler was found and removed.
+    pub fn unregister_handler(&mut self, keyword: &str) -> bool {
+        self.handlers.unregister_global(keyword)
+    }
+
+    /// Unregister a category-specific handler.
+    ///
+    /// Returns `true` if the handler was found and removed.
+    pub fn unregister_category_handler(&mut self, category: &str, keyword: &str) -> bool {
+        self.handlers.unregister_category(category, keyword)
+    }
+
     /// Register a category-specific handler
     pub fn register_category_handler<H>(
         &mut self,
@@ -915,12 +1465,24 @@ impl Config {
     ) {
         let category = category.into();
         let property = property.into();
+        let _ = self
+            .special_categories
+            .add_default_value(&category, property, default_value);
+    }
 
-        // Get the descriptor, add the default value, and re-register
-        if let Some(mut descriptor) = self.special_categories.get_descriptor(&category).cloned() {
-            descriptor.default_values.insert(property, default_value);
-            self.special_categories.register(descriptor);
-        }
+    /// Remove a default value from a special category and all instantiated categories.
+    pub fn remove_special_category_value(
+        &mut self,
+        category: &str,
+        property: &str,
+    ) -> ParseResult<()> {
+        self.special_categories
+            .remove_default_value(category, property)
+    }
+
+    /// Remove a registered special category and all of its instances.
+    pub fn remove_special_category(&mut self, category: &str) {
+        self.special_categories.remove_category(category);
     }
 
     /// Get a special category instance
@@ -937,6 +1499,11 @@ impl Config {
         }
 
         Ok(result)
+    }
+
+    /// Check if a special category instance exists for a given key.
+    pub fn special_category_exists_for_key(&self, category: &str, key: &str) -> bool {
+        self.special_categories.instance_exists(category, key)
     }
 
     /// List all keys for a special category
@@ -1386,6 +1953,7 @@ impl Config {
     ///
     /// let mut config = Config::new();
     /// config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+    /// config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
     /// config.parse("device[mouse] {\n  sensitivity = 1.0\n}").unwrap();
     ///
     /// // Get mutable reference and modify
@@ -1427,10 +1995,12 @@ impl Config {
     ///
     /// ```
     /// # #[cfg(feature = "mutation")] {
-    /// use hyprlang::{Config, SpecialCategoryDescriptor};
+    /// use hyprlang::{Config, ConfigValue, SpecialCategoryDescriptor};
     ///
     /// let mut config = Config::new();
     /// config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+    /// config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
+    /// config.register_special_category_value("device", "repeat_rate", ConfigValue::Int(0));
     /// config.parse("device[mouse] {\n  sensitivity = 1.0\n}\ndevice[keyboard] {\n  repeat_rate = 50\n}").unwrap();
     ///
     /// config.remove_special_category_instance("device", "mouse").unwrap();

--- a/src/features.rs
+++ b/src/features.rs
@@ -134,6 +134,19 @@ impl SourceResolver {
 
     /// Resolve a source path relative to the base directory
     pub fn resolve_path(&self, path: &str) -> ParseResult<PathBuf> {
+        // Expand ~ to home directory
+        let expanded;
+        let path = if let Some(rest) = path.strip_prefix("~/") {
+            if let Ok(home) = std::env::var("HOME") {
+                expanded = format!("{}/{}", home, rest);
+                expanded.as_str()
+            } else {
+                path
+            }
+        } else {
+            path
+        };
+
         let path_obj = Path::new(path);
 
         let resolved = if path_obj.is_absolute() {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -124,6 +124,13 @@ pub enum HandlerScope {
     Category,
 }
 
+pub struct ResolvedHandlerCall<'a> {
+    pub handler: &'a dyn Handler,
+    pub handler_keyword: String,
+    pub actual_keyword: String,
+    pub flags: Option<String>,
+}
+
 /// Manager for keyword handlers
 pub struct HandlerManager {
     /// Global handlers
@@ -181,9 +188,63 @@ impl HandlerManager {
         self.global_handlers.get(keyword).map(|h| h.as_ref())
     }
 
+    fn resolve_in_map<'a>(
+        handlers: &'a HashMap<String, Box<dyn Handler>>,
+        keyword: &str,
+    ) -> Option<ResolvedHandlerCall<'a>> {
+        if let Some(handler) = handlers.get(keyword) {
+            return Some(ResolvedHandlerCall {
+                handler: handler.as_ref(),
+                handler_keyword: keyword.to_string(),
+                actual_keyword: keyword.to_string(),
+                flags: None,
+            });
+        }
+
+        if keyword.contains(':') {
+            return None;
+        }
+
+        let mut best_match: Option<(&str, &dyn Handler)> = None;
+        for (name, handler) in handlers {
+            if !handler.accepts_flags() || !keyword.starts_with(name) {
+                continue;
+            }
+
+            match best_match {
+                Some((best_name, _)) if best_name.len() >= name.len() => {}
+                _ => best_match = Some((name.as_str(), handler.as_ref())),
+            }
+        }
+
+        best_match.map(|(name, handler)| ResolvedHandlerCall {
+            handler,
+            handler_keyword: name.to_string(),
+            actual_keyword: keyword.to_string(),
+            flags: Some(keyword[name.len()..].to_string()),
+        })
+    }
+
+    pub fn resolve_invocation<'a>(
+        &'a self,
+        category_path: &[String],
+        keyword: &str,
+    ) -> Option<ResolvedHandlerCall<'a>> {
+        for i in (0..=category_path.len()).rev() {
+            let path = category_path[..i].join(":");
+            if let Some(handlers) = self.category_handlers.get(&path)
+                && let Some(resolved) = Self::resolve_in_map(handlers, keyword)
+            {
+                return Some(resolved);
+            }
+        }
+
+        Self::resolve_in_map(&self.global_handlers, keyword)
+    }
+
     /// Check if a handler exists for a keyword
     pub fn has_handler(&self, category_path: &[String], keyword: &str) -> bool {
-        self.find_handler(category_path, keyword).is_some()
+        self.resolve_invocation(category_path, keyword).is_some()
     }
 
     /// Execute a handler
@@ -207,10 +268,54 @@ impl HandlerManager {
         }
 
         let context = HandlerContext::new(keyword.to_string(), value.to_string())
-            .with_category(category_path.to_vec())
-            .with_flags(flags.unwrap_or_default());
+            .with_category(category_path.to_vec());
+
+        let context = if let Some(flags) = flags {
+            context.with_flags(flags)
+        } else {
+            context
+        };
 
         handler.handle(&context)
+    }
+
+    pub fn execute_resolved(
+        &self,
+        category_path: &[String],
+        resolved: &ResolvedHandlerCall<'_>,
+        value: &str,
+    ) -> ParseResult<()> {
+        if resolved.flags.is_some() && !resolved.handler.accepts_flags() {
+            return Err(ConfigError::handler(
+                &resolved.actual_keyword,
+                "handler does not accept flags",
+            ));
+        }
+
+        let context = HandlerContext::new(resolved.actual_keyword.clone(), value.to_string())
+            .with_category(category_path.to_vec());
+
+        let context = if let Some(flags) = resolved.flags.clone() {
+            context.with_flags(flags)
+        } else {
+            context
+        };
+
+        resolved.handler.handle(&context)
+    }
+
+    /// Unregister a global handler by keyword
+    pub fn unregister_global(&mut self, keyword: &str) -> bool {
+        self.global_handlers.remove(keyword).is_some()
+    }
+
+    /// Unregister a category-scoped handler
+    pub fn unregister_category(&mut self, category: &str, keyword: &str) -> bool {
+        if let Some(handlers) = self.category_handlers.get_mut(category) {
+            handlers.remove(keyword).is_some()
+        } else {
+            false
+        }
     }
 
     /// Clear all handlers

--- a/src/hyprland.rs
+++ b/src/hyprland.rs
@@ -406,6 +406,64 @@ impl<'a> RuleInstance<'a> {
         Self { values }
     }
 
+    fn parse_color_string(key: &str, value: &str) -> ParseResult<Color> {
+        if value.starts_with("rgba(") && value.ends_with(')') {
+            let inner = &value[5..value.len() - 1];
+            if !inner.contains(',') {
+                return Color::from_hex(inner);
+            }
+
+            let parts: Vec<&str> = inner.split(',').map(|part| part.trim()).collect();
+            if parts.len() != 4 {
+                return Err(ConfigError::invalid_color(value, "rgba needs 4 components"));
+            }
+
+            let r = parts[0]
+                .parse::<u8>()
+                .map_err(|_| ConfigError::invalid_color(value, "invalid r"))?;
+            let g = parts[1]
+                .parse::<u8>()
+                .map_err(|_| ConfigError::invalid_color(value, "invalid g"))?;
+            let b = parts[2]
+                .parse::<u8>()
+                .map_err(|_| ConfigError::invalid_color(value, "invalid b"))?;
+            let a = if parts[3].contains('.') {
+                let alpha = parts[3]
+                    .parse::<f64>()
+                    .map_err(|_| ConfigError::invalid_color(value, "invalid a"))?;
+                (alpha * 255.0).round() as u8
+            } else {
+                parts[3]
+                    .parse::<u8>()
+                    .map_err(|_| ConfigError::invalid_color(value, "invalid a"))?
+            };
+
+            return Ok(Color::from_rgba(r, g, b, a));
+        }
+
+        if value.starts_with("rgb(") && value.ends_with(')') {
+            let inner = &value[4..value.len() - 1];
+            let parts: Vec<&str> = inner.split(',').map(|part| part.trim()).collect();
+            if parts.len() != 3 {
+                return Err(ConfigError::invalid_color(value, "rgb needs 3 components"));
+            }
+
+            let r = parts[0]
+                .parse::<u8>()
+                .map_err(|_| ConfigError::invalid_color(value, "invalid r"))?;
+            let g = parts[1]
+                .parse::<u8>()
+                .map_err(|_| ConfigError::invalid_color(value, "invalid g"))?;
+            let b = parts[2]
+                .parse::<u8>()
+                .map_err(|_| ConfigError::invalid_color(value, "invalid b"))?;
+
+            return Ok(Color::from_rgb(r, g, b));
+        }
+
+        Color::from_hex(value).map_err(|_| ConfigError::type_error(key, "Color", "String"))
+    }
+
     /// Get a value by key
     pub fn get(&self, key: &str) -> ParseResult<&ConfigValue> {
         self.values
@@ -426,6 +484,10 @@ impl<'a> RuleInstance<'a> {
     pub fn get_int(&self, key: &str) -> ParseResult<i64> {
         match self.get(key)? {
             ConfigValue::Int(i) => Ok(*i),
+            ConfigValue::String(s) => ConfigValue::parse_bool(s)
+                .map(|b| if b { 1 } else { 0 })
+                .or_else(|_| ConfigValue::parse_int(s))
+                .map_err(|_| ConfigError::type_error(key, "Int", "String")),
             v => Err(ConfigError::type_error(key, "Int", v.type_name())),
         }
     }
@@ -434,6 +496,10 @@ impl<'a> RuleInstance<'a> {
     pub fn get_float(&self, key: &str) -> ParseResult<f64> {
         match self.get(key)? {
             ConfigValue::Float(f) => Ok(*f),
+            ConfigValue::Int(i) => Ok(*i as f64),
+            ConfigValue::String(s) => ConfigValue::parse_float(s)
+                .or_else(|_| ConfigValue::parse_int(s).map(|i| i as f64))
+                .map_err(|_| ConfigError::type_error(key, "Float", "String")),
             v => Err(ConfigError::type_error(key, "Float", v.type_name())),
         }
     }
@@ -442,6 +508,7 @@ impl<'a> RuleInstance<'a> {
     pub fn get_color(&self, key: &str) -> ParseResult<Color> {
         match self.get(key)? {
             ConfigValue::Color(c) => Ok(*c),
+            ConfigValue::String(s) => Self::parse_color_string(key, s),
             v => Err(ConfigError::type_error(key, "Color", v.type_name())),
         }
     }
@@ -552,10 +619,16 @@ impl Hyprland {
     /// Register all Hyprland-specific special categories
     fn register_all_special_categories(config: &mut Config) {
         // Device is a keyed category: device[name] { ... }
-        config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+        config.register_special_category(
+            SpecialCategoryDescriptor::keyed("device", "name").with_ignore_missing(),
+        );
+        config.register_special_category_value("device", "enabled", ConfigValue::Int(0));
+        config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
 
         // Monitor is a keyed category: monitor[name] { ... } (for per-monitor settings)
-        config.register_special_category(SpecialCategoryDescriptor::keyed("monitor", "name"));
+        config.register_special_category(
+            SpecialCategoryDescriptor::keyed("monitor", "name").with_ignore_missing(),
+        );
 
         // Windowrule v3: windowrule { name = ... }
         config.register_special_category(SpecialCategoryDescriptor::keyed("windowrule", "name"));

--- a/src/hyprlang.pest
+++ b/src/hyprlang.pest
@@ -104,7 +104,7 @@ string_value = @{
 }
 
 quoted_string = @{ "\"" ~ (!("\"") ~ ANY)* ~ "\"" }
-unquoted_string = @{ (!(NEWLINE | "#") ~ ANY)+ }
+unquoted_string = @{ ("##" | !(NEWLINE | "#") ~ ANY)+ }
 
 // Identifiers (allow dots for things like col.active_border)
 ident = @{ (ASCII_ALPHANUMERIC | "_" | "-" | ".")+ }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@
 //! ### Special Categories
 //!
 //! ```rust
-//! use hyprlang::{Config, SpecialCategoryDescriptor};
+//! use hyprlang::{Config, ConfigValue, SpecialCategoryDescriptor};
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut config = Config::new();
@@ -111,6 +111,8 @@
 //! config.register_special_category(
 //!     SpecialCategoryDescriptor::keyed("device", "name")
 //! );
+//! config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
+//! config.register_special_category_value("device", "repeat_rate", ConfigValue::Int(0));
 //!
 //! config.parse(r#"
 //! device[mouse] {
@@ -249,5 +251,874 @@ mod tests {
         let pos = config.get_vec2("pos").unwrap();
         assert_eq!(pos.x, 100.0);
         assert_eq!(pos.y, 200.0);
+    }
+
+    // ========== ConfigOptions ==========
+
+    #[test]
+    fn test_verify_only_no_values_stored() {
+        let mut config = Config::with_options(ConfigOptions {
+            verify_only: true,
+            ..Default::default()
+        });
+        config.parse("key = 42").unwrap();
+        assert!(!config.contains("key"));
+    }
+
+    #[test]
+    fn test_verify_only_detects_errors() {
+        let mut config = Config::with_options(ConfigOptions {
+            verify_only: true,
+            ..Default::default()
+        });
+        config.parse("key = value").unwrap();
+        assert!(config.parse("= value").is_err());
+    }
+
+    #[test]
+    fn test_verify_only_variables_not_stored() {
+        let mut config = Config::with_options(ConfigOptions {
+            verify_only: true,
+            ..Default::default()
+        });
+        config.parse("$VAR = hello\nkey = $VAR").unwrap();
+        assert!(config.get_variable("VAR").is_none());
+        assert!(!config.contains("key"));
+    }
+
+    #[test]
+    fn test_allow_missing_config() {
+        let mut config = Config::with_options(ConfigOptions {
+            allow_missing_config: true,
+            ..Default::default()
+        });
+        let result = config.parse_file("/nonexistent/path/to/config.conf");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_allow_missing_config_false() {
+        let mut config = Config::with_options(ConfigOptions {
+            allow_missing_config: false,
+            ..Default::default()
+        });
+        let result = config.parse_file("/nonexistent/path/to/config.conf");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_path_is_stream() {
+        let mut config = Config::with_options(ConfigOptions {
+            path_is_stream: true,
+            ..Default::default()
+        });
+        config.parse_file("key = 42").unwrap();
+        assert_eq!(config.get_int("key").unwrap(), 42);
+    }
+
+    #[test]
+    fn test_path_is_stream_with_categories() {
+        let mut config = Config::with_options(ConfigOptions {
+            path_is_stream: true,
+            ..Default::default()
+        });
+        config
+            .parse_file("general {\n  border_size = 3\n}")
+            .unwrap();
+        assert_eq!(config.get_int("general:border_size").unwrap(), 3);
+    }
+
+    // ========== change_root_path ==========
+
+    #[test]
+    fn test_change_root_path() {
+        let mut config = Config::new();
+        config.change_root_path(std::path::Path::new("/tmp/new/path"));
+        assert!(config.parse("key = value").is_ok());
+    }
+
+    // ========== special_category_exists_for_key ==========
+
+    #[test]
+    fn test_special_category_exists_for_key() {
+        let mut config = Config::new();
+        config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+        config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
+        config
+            .parse("device[mouse] {\n  sensitivity = 2.5\n}")
+            .unwrap();
+
+        assert!(config.special_category_exists_for_key("device", "mouse"));
+        assert!(!config.special_category_exists_for_key("device", "keyboard"));
+        assert!(!config.special_category_exists_for_key("nonexistent", "key"));
+    }
+
+    #[test]
+    fn test_special_category_exists_multiple_instances() {
+        let mut config = Config::new();
+        config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+        config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
+        config.register_special_category_value("device", "repeat_rate", ConfigValue::Int(0));
+        config
+            .parse(
+                r#"
+        device[mouse] {
+            sensitivity = 1.0
+        }
+        device[keyboard] {
+            repeat_rate = 50
+        }
+    "#,
+            )
+            .unwrap();
+
+        assert!(config.special_category_exists_for_key("device", "mouse"));
+        assert!(config.special_category_exists_for_key("device", "keyboard"));
+        assert!(!config.special_category_exists_for_key("device", "touchpad"));
+    }
+
+    #[test]
+    fn test_special_category_bracketless_key() {
+        // Key resolved from inner `name = ...` assignment instead of brackets
+        let mut config = Config::new();
+        config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+        config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
+        config
+            .parse(
+                r#"
+        device {
+            name = mouse
+            sensitivity = 2.5
+        }
+    "#,
+            )
+            .unwrap();
+
+        assert!(config.special_category_exists_for_key("device", "mouse"));
+        let instance = config.get_special_category("device", "mouse").unwrap();
+        assert_eq!(instance.get("sensitivity").unwrap().as_float().unwrap(), 2.5);
+    }
+
+    #[test]
+    fn test_special_category_bracketless_requires_key_first() {
+        let mut config = Config::new();
+        config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+        config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
+
+        let result = config.parse(
+            r#"
+        device {
+            sensitivity = 2.5
+            name = mouse
+        }
+    "#,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_special_category_bracketless_multiple() {
+        let mut config = Config::new();
+        config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+        config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
+        config.register_special_category_value("device", "repeat_rate", ConfigValue::Int(0));
+        config
+            .parse(
+                r#"
+        device {
+            name = mouse
+            sensitivity = 1.0
+        }
+        device {
+            name = keyboard
+            repeat_rate = 50
+        }
+    "#,
+            )
+            .unwrap();
+
+        assert!(config.special_category_exists_for_key("device", "mouse"));
+        assert!(config.special_category_exists_for_key("device", "keyboard"));
+    }
+
+    #[test]
+    fn test_special_category_state_cleanup() {
+        let mut config = Config::new();
+        config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+        config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
+        config
+            .parse(
+                r#"
+        device[mouse] {
+            sensitivity = 2.0
+        }
+
+        regular_key = after_special_category
+    "#,
+            )
+            .unwrap();
+
+        assert_eq!(
+            config.get_string("regular_key").unwrap(),
+            "after_special_category"
+        );
+    }
+
+    #[test]
+    fn test_special_category_ignore_missing() {
+        let mut config = Config::new();
+        config.register_special_category(
+            SpecialCategoryDescriptor::keyed("device", "name").with_ignore_missing(),
+        );
+
+        let keys = config.list_special_category_keys("device");
+        assert!(keys.is_empty());
+    }
+
+    // ========== unregister_handler ==========
+
+    #[test]
+    fn test_unregister_handler() {
+        let mut config = Config::new();
+        config.register_handler_fn("exec", |_ctx| Ok(()));
+
+        config.parse("exec = test").unwrap();
+
+        assert!(config.unregister_handler("exec"));
+
+        config.parse("exec = test2").unwrap();
+        assert_eq!(config.get_string("exec").unwrap(), "test2");
+    }
+
+    #[test]
+    fn test_unregister_handler_not_found() {
+        let mut config = Config::new();
+        assert!(!config.unregister_handler("nonexistent"));
+    }
+
+    #[test]
+    fn test_unregister_category_handler() {
+        let mut config = Config::new();
+        config.register_category_handler_fn("animations", "bezier", |_ctx| Ok(()));
+
+        assert!(config.unregister_category_handler("animations", "bezier"));
+        assert!(!config.unregister_category_handler("animations", "bezier"));
+    }
+
+    // ========== Handler Scoping ==========
+
+    #[test]
+    fn test_global_handler_in_category() {
+        let mut config = Config::new();
+        config.register_handler_fn("bind", |_ctx| Ok(()));
+
+        config
+            .parse(
+                r#"
+        bind = SUPER, Q, exec, terminal
+        general {
+            bind = SUPER, C, killactive
+        }
+    "#,
+            )
+            .unwrap();
+
+        let calls = config.get_handler_calls("bind").unwrap();
+        assert_eq!(calls.len(), 1);
+
+        let cat_calls = config.get_handler_calls("general:bind").unwrap();
+        assert_eq!(cat_calls.len(), 1);
+    }
+
+    #[test]
+    fn test_category_handler_only_fires_in_scope() {
+        let mut config = Config::new();
+        config.register_category_handler_fn("animations", "bezier", |_ctx| Ok(()));
+
+        config
+            .parse(
+                r#"
+        animations {
+            bezier = myBezier, 0.05, 0.9, 0.1, 1.05
+        }
+    "#,
+            )
+            .unwrap();
+
+        let calls = config.get_handler_calls("animations:bezier").unwrap();
+        assert_eq!(calls.len(), 1);
+    }
+
+    #[test]
+    fn test_flagged_handler_prefix_invocation() {
+        let mut config = Config::new();
+        let seen_flags = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let seen_flags_ref = std::rc::Rc::clone(&seen_flags);
+
+        config.register_handler(
+            "flags",
+            FunctionHandler::with_flags("flags", move |ctx| {
+                seen_flags_ref.borrow_mut().push((
+                    ctx.keyword.clone(),
+                    ctx.flags.clone(),
+                    ctx.value.clone(),
+                ));
+                Ok(())
+            }),
+        );
+
+        config.parse("flagsabc = test").unwrap();
+
+        let seen = seen_flags.borrow();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].0, "flagsabc");
+        assert_eq!(seen[0].1.as_deref(), Some("abc"));
+        assert_eq!(seen[0].2, "test");
+        assert!(config.get("flagsabc").is_err());
+        assert_eq!(config.get_handler_calls("flags").unwrap(), &vec!["test".to_string()]);
+    }
+
+    // ========== Dynamic Variable Propagation ==========
+
+    #[test]
+    fn test_dynamic_variable_propagation() {
+        let mut config = Config::new();
+        config
+            .parse(
+                r#"
+        $GAPS = 10
+        gaps_in = $GAPS
+        gaps_out = $GAPS
+    "#,
+            )
+            .unwrap();
+
+        assert_eq!(config.get_int("gaps_in").unwrap(), 10);
+        assert_eq!(config.get_int("gaps_out").unwrap(), 10);
+
+        config.parse_dynamic("$GAPS = 20").unwrap();
+
+        assert_eq!(config.get_int("gaps_in").unwrap(), 20);
+        assert_eq!(config.get_int("gaps_out").unwrap(), 20);
+    }
+
+    #[test]
+    fn test_dynamic_variable_propagation_with_expression() {
+        let mut config = Config::new();
+        config
+            .parse(
+                r#"
+        $BASE = 10
+        doubled = {{BASE * 2}}
+    "#,
+            )
+            .unwrap();
+
+        assert_eq!(config.get_int("doubled").unwrap(), 20);
+
+        config.parse_dynamic("$BASE = 15").unwrap();
+        assert_eq!(config.get_variable("BASE").unwrap(), "15");
+    }
+
+    #[test]
+    fn test_dynamic_variable_chain_propagation() {
+        let mut config = Config::new();
+        config
+            .parse(
+                r#"
+        $A = hello
+        $B = $A world
+        greeting = $B
+    "#,
+            )
+            .unwrap();
+
+        assert_eq!(config.get_string("greeting").unwrap(), "hello world");
+
+        config.parse_dynamic("$A = hi").unwrap();
+
+        assert_eq!(config.get_variable("B").unwrap(), "hi world");
+    }
+
+    #[test]
+    fn test_dynamic_variable_replay_does_not_duplicate_handler_side_effects() {
+        let mut config = Config::new();
+        let seen_values = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let seen_values_ref = std::rc::Rc::clone(&seen_values);
+
+        config.register_handler_fn("exec", move |ctx| {
+            seen_values_ref.borrow_mut().push(ctx.value.clone());
+            Ok(())
+        });
+
+        config
+            .parse(
+                r#"
+        $A = 1
+        exec = $A
+    "#,
+            )
+            .unwrap();
+        config.parse_dynamic("$A = 2").unwrap();
+        config.parse_dynamic("$A = 3").unwrap();
+
+        assert_eq!(
+            seen_values.borrow().as_slice(),
+            &["1".to_string(), "2".to_string(), "3".to_string()]
+        );
+        assert_eq!(config.get_handler_calls("exec").unwrap().len(), 3);
+    }
+
+    #[test]
+    fn test_dynamic_no_propagation_for_non_variable_lines() {
+        let mut config = Config::new();
+        config
+            .parse(
+                r#"
+        $VAR = 10
+        static_key = 42
+        dynamic_key = $VAR
+    "#,
+            )
+            .unwrap();
+
+        assert_eq!(config.get_int("static_key").unwrap(), 42);
+        assert_eq!(config.get_int("dynamic_key").unwrap(), 10);
+
+        config.parse_dynamic("$VAR = 20").unwrap();
+
+        assert_eq!(config.get_int("static_key").unwrap(), 42);
+        assert_eq!(config.get_int("dynamic_key").unwrap(), 20);
+    }
+
+    // ========== parse_dynamic_kv ==========
+
+    #[test]
+    fn test_parse_dynamic_kv() {
+        let mut config = Config::new();
+        config.parse("key = 10").unwrap();
+        assert_eq!(config.get_int("key").unwrap(), 10);
+
+        config.parse_dynamic_kv("key", "42").unwrap();
+        assert_eq!(config.get_int("key").unwrap(), 42);
+    }
+
+    #[test]
+    fn test_parse_dynamic_kv_category_path() {
+        let mut config = Config::new();
+        config.parse("cat {\n  val = 1\n}").unwrap();
+        assert_eq!(config.get_int("cat:val").unwrap(), 1);
+
+        config.parse_dynamic_kv("cat:val", "99").unwrap();
+        assert_eq!(config.get_int("cat:val").unwrap(), 99);
+    }
+
+    // ========== Dynamic special category bracket syntax ==========
+
+    #[test]
+    fn test_dynamic_special_category_bracket() {
+        let mut config = Config::new();
+        config.register_special_category(SpecialCategoryDescriptor::keyed("special", "name"));
+        config.register_special_category_value("special", "value", ConfigValue::Int(0));
+        config
+            .parse("special[a] {\n  value = 1\n}")
+            .unwrap();
+
+        assert_eq!(
+            config
+                .get_special_category("special", "a")
+                .unwrap()
+                .get("value")
+                .unwrap()
+                .as_int()
+                .unwrap(),
+            1
+        );
+
+        // Update via dynamic bracket syntax
+        config.parse_dynamic("special[a]:value = 69").unwrap();
+        assert_eq!(
+            config
+                .get_special_category("special", "a")
+                .unwrap()
+                .get("value")
+                .unwrap()
+                .as_int()
+                .unwrap(),
+            69
+        );
+    }
+
+    #[test]
+    fn test_dynamic_special_category_bracket_creates_instance() {
+        let mut config = Config::new();
+        config.register_special_category(SpecialCategoryDescriptor::keyed("special", "name"));
+        config.register_special_category_value("special", "value", ConfigValue::Int(0));
+
+        // Dynamic bracket syntax creates instance if it doesn't exist
+        config.parse_dynamic("special[new]:value = 42").unwrap();
+        assert!(config.special_category_exists_for_key("special", "new"));
+        assert_eq!(
+            config
+                .get_special_category("special", "new")
+                .unwrap()
+                .get("value")
+                .unwrap()
+                .as_int()
+                .unwrap(),
+            42
+        );
+    }
+
+    #[test]
+    fn test_dynamic_special_category_rejects_unknown_property() {
+        let mut config = Config::new();
+        config.register_special_category(SpecialCategoryDescriptor::keyed("special", "name"));
+        config.register_special_category_value("special", "value", ConfigValue::Int(0));
+
+        assert!(config.parse_dynamic("special[a]:typo = 1").is_err());
+        assert!(!config.special_category_exists_for_key("special", "a"));
+
+        config.register_special_category(SpecialCategoryDescriptor::static_category(
+            "specialGeneric:two",
+        ));
+        config.register_special_category_value(
+            "specialGeneric:two",
+            "value",
+            ConfigValue::Int(0),
+        );
+
+        assert!(config.parse_dynamic("specialGeneric:two:typo = 1").is_err());
+        assert!(
+            config
+                .get_special_category("specialGeneric:two", "static")
+                .unwrap()
+                .get("typo")
+                .is_none()
+        );
+    }
+
+    // ========== Colon-scoped special categories ==========
+
+    #[test]
+    fn test_colon_scoped_special_category() {
+        let mut config = Config::new();
+        config.register_special_category(
+            SpecialCategoryDescriptor::static_category("specialGeneric:one"),
+        );
+        config.register_special_category_value(
+            "specialGeneric:one",
+            "value",
+            ConfigValue::Int(0),
+        );
+
+        config
+            .parse(
+                r#"
+        specialGeneric {
+            one {
+                value = 1
+            }
+        }
+    "#,
+            )
+            .unwrap();
+
+        let instance = config.get_special_category("specialGeneric:one", "static").unwrap();
+        assert_eq!(instance.get("value").unwrap().as_int().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_colon_scoped_special_category_flat_syntax() {
+        let mut config = Config::new();
+        config.register_special_category(
+            SpecialCategoryDescriptor::static_category("specialGeneric:two"),
+        );
+        config.register_special_category_value(
+            "specialGeneric:two",
+            "hola",
+            ConfigValue::String(String::new()),
+        );
+
+        // Direct colon-separated key assignment at root level
+        config.parse("specialGeneric:two:hola = rose").unwrap();
+
+        let instance = config.get_special_category("specialGeneric:two", "static").unwrap();
+        assert_eq!(
+            instance.get("hola").unwrap().as_string().unwrap(),
+            "rose"
+        );
+    }
+
+    #[test]
+    fn test_colon_scoped_multiple_categories() {
+        let mut config = Config::new();
+        config.register_special_category(
+            SpecialCategoryDescriptor::static_category("generic:one"),
+        );
+        config.register_special_category_value("generic:one", "val", ConfigValue::Int(0));
+        config.register_special_category(
+            SpecialCategoryDescriptor::static_category("generic:two"),
+        );
+        config.register_special_category_value("generic:two", "val", ConfigValue::Int(0));
+
+        config
+            .parse(
+                r#"
+        generic {
+            one {
+                val = 10
+            }
+            two {
+                val = 20
+            }
+        }
+    "#,
+            )
+            .unwrap();
+
+        let one = config.get_special_category("generic:one", "static").unwrap();
+        assert_eq!(one.get("val").unwrap().as_int().unwrap(), 10);
+
+        let two = config.get_special_category("generic:two", "static").unwrap();
+        assert_eq!(two.get("val").unwrap().as_int().unwrap(), 20);
+    }
+
+    #[test]
+    fn test_same_keyword_special_category_prefers_nested_category_match() {
+        let mut config = Config::new();
+        let handler_values = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let handler_values_ref = std::rc::Rc::clone(&handler_values);
+
+        config.register_handler_fn("sameKeywordSpecialCat", move |ctx| {
+            handler_values_ref.borrow_mut().push(ctx.value.clone());
+            Ok(())
+        });
+
+        config.register_special_category(
+            SpecialCategoryDescriptor::static_category("sameKeywordSpecialCat")
+                .with_ignore_missing(),
+        );
+        config.register_special_category(
+            SpecialCategoryDescriptor::static_category("sameKeywordSpecialCat:one")
+                .with_ignore_missing(),
+        );
+        config.register_special_category_value(
+            "sameKeywordSpecialCat:one",
+            "some_size",
+            ConfigValue::Int(10),
+        );
+        config.register_special_category_value(
+            "sameKeywordSpecialCat:one",
+            "some_radius",
+            ConfigValue::Float(0.0),
+        );
+        config.register_special_category(
+            SpecialCategoryDescriptor::static_category("sameKeywordSpecialCat:two")
+                .with_ignore_missing(),
+        );
+        config.register_special_category_value(
+            "sameKeywordSpecialCat:two",
+            "hola",
+            ConfigValue::String(String::new()),
+        );
+
+        config
+            .parse(
+                r#"
+        sameKeywordSpecialCat = pablo
+        sameKeywordSpecialCat:two:hola = rose
+        sameKeywordSpecialCat {
+            one {
+                some_size = 44
+                some_radius = 7.6
+            }
+        }
+    "#,
+            )
+            .unwrap();
+
+        assert_eq!(handler_values.borrow().as_slice(), &["pablo".to_string()]);
+        assert_eq!(
+            config
+                .get_special_category("sameKeywordSpecialCat:one", "static")
+                .unwrap()
+                .get("some_size")
+                .unwrap()
+                .as_int()
+                .unwrap(),
+            44
+        );
+        assert_eq!(
+            config
+                .get_special_category("sameKeywordSpecialCat:one", "static")
+                .unwrap()
+                .get("some_radius")
+                .unwrap()
+                .as_float()
+                .unwrap(),
+            7.6
+        );
+        assert_eq!(
+            config
+                .get_special_category("sameKeywordSpecialCat:two", "static")
+                .unwrap()
+                .get("hola")
+                .unwrap()
+                .as_string()
+                .unwrap(),
+            "rose"
+        );
+    }
+
+    // ========== Anonymous nested special categories ==========
+
+    #[test]
+    fn test_anonymous_nested_flat_keys() {
+        let mut config = Config::new();
+        config
+            .register_special_category(SpecialCategoryDescriptor::anonymous("anon_nested"));
+        config.register_special_category_value(
+            "anon_nested",
+            "nested:value1",
+            ConfigValue::Int(0),
+        );
+        config.register_special_category_value(
+            "anon_nested",
+            "nested:value2",
+            ConfigValue::Int(0),
+        );
+
+        config
+            .parse(
+                r#"
+        anon_nested {
+            nested:value1 = 1
+            nested:value2 = 2
+        }
+    "#,
+            )
+            .unwrap();
+
+        let keys = config.list_special_category_keys("anon_nested");
+        assert_eq!(keys.len(), 1);
+        let instance = config
+            .get_special_category("anon_nested", &keys[0])
+            .unwrap();
+        assert_eq!(instance.get("nested:value1").unwrap().as_int().unwrap(), 1);
+        assert_eq!(instance.get("nested:value2").unwrap().as_int().unwrap(), 2);
+    }
+
+    #[test]
+    fn test_anonymous_nested_block_syntax() {
+        let mut config = Config::new();
+        config
+            .register_special_category(SpecialCategoryDescriptor::anonymous("anon_nested"));
+        config.register_special_category_value(
+            "anon_nested",
+            "nested:value1",
+            ConfigValue::Int(0),
+        );
+        config.register_special_category_value(
+            "anon_nested",
+            "nested:value2",
+            ConfigValue::Int(0),
+        );
+
+        config
+            .parse(
+                r#"
+        anon_nested {
+            nested {
+                value1 = 3
+                value2 = 4
+            }
+        }
+    "#,
+            )
+            .unwrap();
+
+        let keys = config.list_special_category_keys("anon_nested");
+        assert_eq!(keys.len(), 1);
+        let instance = config
+            .get_special_category("anon_nested", &keys[0])
+            .unwrap();
+        assert_eq!(instance.get("nested:value1").unwrap().as_int().unwrap(), 3);
+        assert_eq!(instance.get("nested:value2").unwrap().as_int().unwrap(), 4);
+    }
+
+    #[test]
+    fn test_anonymous_special_category_accepts_explicit_dynamic_keys() {
+        let mut config = Config::new();
+        config.register_special_category(SpecialCategoryDescriptor::anonymous(
+            "specialAnonymousNested",
+        ));
+        config.register_special_category_value(
+            "specialAnonymousNested",
+            "nested:value1",
+            ConfigValue::Int(0),
+        );
+        config.register_special_category_value(
+            "specialAnonymousNested",
+            "nested:value2",
+            ConfigValue::Int(0),
+        );
+
+        config
+            .parse(
+                r#"
+        specialAnonymousNested {
+            nested:value1 = 1
+            nested:value2 = 2
+        }
+        specialAnonymousNested {
+            nested:value1 = 3
+            nested:value2 = 4
+        }
+    "#,
+            )
+            .unwrap();
+
+        let keys = config.list_special_category_keys("specialAnonymousNested");
+        assert_eq!(keys.len(), 2);
+        assert!(keys.contains(&"1".to_string()));
+        assert!(keys.contains(&"2".to_string()));
+
+        config
+            .parse_dynamic("specialAnonymousNested[c]:nested:value1 = 5")
+            .unwrap();
+        config
+            .parse_dynamic("specialAnonymousNested[c]:nested:value2 = 6")
+            .unwrap();
+
+        let instance = config
+            .get_special_category("specialAnonymousNested", "c")
+            .unwrap();
+        assert_eq!(instance.get("nested:value1").unwrap().as_int().unwrap(), 5);
+        assert_eq!(instance.get("nested:value2").unwrap().as_int().unwrap(), 6);
+    }
+
+    #[test]
+    fn test_change_root_path_uses_parent_of_config_file() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_dir =
+            std::env::temp_dir().join(format!("hyprlang-change-root-{unique}-{}", std::process::id()));
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        let root_config = temp_dir.join("main.conf");
+        let included = temp_dir.join("included.conf");
+        std::fs::write(&included, "included = 42\n").unwrap();
+
+        let mut config = Config::new();
+        config.change_root_path(&root_config);
+        config.parse("source = included.conf").unwrap();
+
+        assert_eq!(config.get_int("included").unwrap(), 42);
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 }

--- a/src/mutation.rs
+++ b/src/mutation.rs
@@ -38,6 +38,7 @@
 //!
 //! let mut config = Config::new();
 //! config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+//! config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
 //! config.parse("device[mouse] {\n  sensitivity = 1.0\n}").unwrap();
 //!
 //! let mut mouse = config.get_special_category_mut("device", "mouse").unwrap();
@@ -183,6 +184,12 @@ impl<'a> MutableVariable<'a> {
 ///
 /// let mut config = Config::new();
 /// config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+/// config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
+/// config.register_special_category_value(
+///     "device",
+///     "accel_profile",
+///     ConfigValue::String(String::new()),
+/// );
 /// config.parse("device[mouse] {\n  sensitivity = 1.0\n}").unwrap();
 ///
 /// let mut mouse = config.get_special_category_mut("device", "mouse").unwrap();
@@ -219,10 +226,11 @@ impl<'a> MutableCategoryInstance<'a> {
     ///
     /// ```
     /// # #[cfg(feature = "mutation")] {
-    /// use hyprlang::{Config, SpecialCategoryDescriptor};
+    /// use hyprlang::{Config, ConfigValue, SpecialCategoryDescriptor};
     ///
     /// let mut config = Config::new();
     /// config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+    /// config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
     /// config.parse("device[mouse] {\n  sensitivity = 1.0\n}").unwrap();
     ///
     /// let mouse = config.get_special_category_mut("device", "mouse").unwrap();
@@ -246,11 +254,17 @@ impl<'a> MutableCategoryInstance<'a> {
     ///
     /// ```
     /// # #[cfg(feature = "mutation")] {
-    /// use hyprlang::{Config, ConfigValue, SpecialCategoryDescriptor};
-    ///
-    /// let mut config = Config::new();
-    /// config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
-    /// config.parse("device[mouse] {\n  sensitivity = 1.0\n}").unwrap();
+/// use hyprlang::{Config, ConfigValue, SpecialCategoryDescriptor};
+///
+/// let mut config = Config::new();
+/// config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+/// config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
+/// config.register_special_category_value(
+///     "device",
+///     "accel_profile",
+///     ConfigValue::String(String::new()),
+/// );
+/// config.parse("device[mouse] {\n  sensitivity = 1.0\n}").unwrap();
     ///
     /// let mut mouse = config.get_special_category_mut("device", "mouse").unwrap();
     /// mouse.set("sensitivity", ConfigValue::Float(2.5)).unwrap();
@@ -278,11 +292,17 @@ impl<'a> MutableCategoryInstance<'a> {
     ///
     /// ```
     /// # #[cfg(feature = "mutation")] {
-    /// use hyprlang::{Config, ConfigValue, SpecialCategoryDescriptor};
-    ///
-    /// let mut config = Config::new();
-    /// config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
-    /// config.parse("device[mouse] {\n  sensitivity = 1.0\n  accel_profile = flat\n}").unwrap();
+/// use hyprlang::{Config, ConfigValue, SpecialCategoryDescriptor};
+///
+/// let mut config = Config::new();
+/// config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+/// config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
+/// config.register_special_category_value(
+///     "device",
+///     "accel_profile",
+///     ConfigValue::String(String::new()),
+/// );
+/// config.parse("device[mouse] {\n  sensitivity = 1.0\n  accel_profile = flat\n}").unwrap();
     ///
     /// let mut mouse = config.get_special_category_mut("device", "mouse").unwrap();
     /// let removed = mouse.remove("accel_profile").unwrap();
@@ -307,10 +327,11 @@ impl<'a> MutableCategoryInstance<'a> {
     ///
     /// ```
     /// # #[cfg(feature = "mutation")] {
-    /// use hyprlang::{Config, SpecialCategoryDescriptor};
+    /// use hyprlang::{Config, ConfigValue, SpecialCategoryDescriptor};
     ///
     /// let mut config = Config::new();
     /// config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+    /// config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
     /// config.parse("device[mouse] {\n  sensitivity = 1.0\n}").unwrap();
     ///
     /// let mouse = config.get_special_category_mut("device", "mouse").unwrap();
@@ -327,10 +348,11 @@ impl<'a> MutableCategoryInstance<'a> {
     ///
     /// ```
     /// # #[cfg(feature = "mutation")] {
-    /// use hyprlang::{Config, SpecialCategoryDescriptor};
+    /// use hyprlang::{Config, ConfigValue, SpecialCategoryDescriptor};
     ///
     /// let mut config = Config::new();
     /// config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+    /// config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
     /// config.parse("device[mouse] {\n  sensitivity = 1.0\n}").unwrap();
     ///
     /// let mouse = config.get_special_category_mut("device", "mouse").unwrap();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -259,13 +259,12 @@ impl HyprlangParser {
 
             Rule::string_value => {
                 let s = pair.as_str();
-                // Remove quotes if present
-                let s = if s.starts_with('"') && s.ends_with('"') {
-                    &s[1..s.len() - 1]
+                if s.starts_with('"') && s.ends_with('"') {
+                    Ok(Value::String(s.to_string()))
                 } else {
-                    s
-                };
-                Ok(Value::String(s.to_string()))
+                    // Unquoted: unescape ## -> # (comment escaping)
+                    Ok(Value::String(s.replace("##", "#")))
+                }
             }
 
             _ => Ok(Value::String(pair.as_str().to_string())),

--- a/src/special_categories.rs
+++ b/src/special_categories.rs
@@ -125,8 +125,8 @@ pub struct SpecialCategoryManager {
     /// Instances of special categories: category_name -> key -> instance
     instances: HashMap<String, HashMap<String, SpecialCategoryInstance>>,
 
-    /// Counter for anonymous category keys
-    anonymous_counters: HashMap<String, usize>,
+    /// Next auto-assigned anonymous key (global across categories, matching upstream)
+    next_anonymous_key: usize,
 }
 
 impl SpecialCategoryManager {
@@ -134,13 +134,28 @@ impl SpecialCategoryManager {
         Self {
             descriptors: HashMap::new(),
             instances: HashMap::new(),
-            anonymous_counters: HashMap::new(),
+            next_anonymous_key: 1,
         }
     }
 
     /// Register a special category descriptor
     pub fn register(&mut self, descriptor: SpecialCategoryDescriptor) {
-        self.descriptors.insert(descriptor.name.clone(), descriptor);
+        let category_name = descriptor.name.clone();
+        let category_type = descriptor.category_type;
+        let default_values = descriptor.default_values.clone();
+
+        self.descriptors.insert(category_name.clone(), descriptor);
+
+        if category_type == SpecialCategoryType::Static {
+            let instances = self.instances.entry(category_name).or_default();
+            let instance = instances
+                .entry("static".to_string())
+                .or_insert_with(|| SpecialCategoryInstance::new(Some("static".to_string())));
+
+            for (prop_name, default_value) in default_values {
+                instance.set(prop_name, ConfigValueEntry::with_default(default_value));
+            }
+        }
     }
 
     /// Check if a category is registered
@@ -179,31 +194,28 @@ impl SpecialCategoryManager {
                 "static".to_string()
             }
             SpecialCategoryType::Anonymous => {
-                if key.is_some() {
-                    return Err(ConfigError::custom(format!(
-                        "Anonymous category '{}' cannot have an explicit key",
-                        category_name
-                    )));
+                if let Some(explicit_key) = key {
+                    explicit_key
+                } else {
+                    let key = self.next_anonymous_key.to_string();
+                    self.next_anonymous_key += 1;
+                    key
                 }
-                let counter = self
-                    .anonymous_counters
-                    .entry(category_name.to_string())
-                    .or_insert(0);
-                let key = format!("anonymous_{}", counter);
-                *counter += 1;
-                key
             }
         };
+
+        if self.instance_exists(category_name, &instance_key) {
+            return Ok(instance_key);
+        }
 
         // Create the instance with default values
         let mut instance = SpecialCategoryInstance::new(Some(instance_key.clone()));
 
         // Apply default values from descriptor
         for (prop_name, default_value) in &descriptor.default_values {
-            let raw = default_value.to_string();
             instance.set(
                 prop_name.clone(),
-                ConfigValueEntry::new(default_value.clone(), raw),
+                ConfigValueEntry::with_default(default_value.clone()),
             );
         }
 
@@ -291,6 +303,15 @@ impl SpecialCategoryManager {
 
     /// Get all keys for a special category
     pub fn list_keys(&self, category_name: &str) -> Vec<String> {
+        if self
+            .descriptors
+            .get(category_name)
+            .map(|descriptor| descriptor.category_type == SpecialCategoryType::Static)
+            .unwrap_or(false)
+        {
+            return Vec::new();
+        }
+
         self.instances
             .get(category_name)
             .map(|instances| instances.keys().cloned().collect())
@@ -325,10 +346,135 @@ impl SpecialCategoryManager {
             .unwrap_or(false)
     }
 
-    /// Clear all instances (but keep descriptors)
-    pub fn clear_instances(&mut self) {
+    /// Find a registered special category whose name is a prefix of the given key path.
+    ///
+    /// For colon-scoped categories like `specialGeneric:one`, this matches when the
+    /// full key is `specialGeneric:one:value`. Returns (category_name, property_name).
+    pub fn find_matching_category(&self, full_key: &str) -> Option<(String, String)> {
+        // Check longest names first to match most specific category
+        let mut matches: Vec<_> = self
+            .descriptors
+            .keys()
+            .filter(|name| {
+                full_key.starts_with(name.as_str()) && full_key[name.len()..].starts_with(':')
+            })
+            .collect();
+        matches.sort_by(|a, b| b.len().cmp(&a.len()));
+
+        matches.first().map(|name| {
+            let prop = full_key[name.len() + 1..].to_string();
+            (name.to_string(), prop)
+        })
+    }
+
+    /// Find a registered special category whose segment path is a prefix of the given segments.
+    ///
+    /// Returns the full category name and the number of path segments it consumed.
+    pub fn find_matching_category_segments(
+        &self,
+        path_segments: &[String],
+    ) -> Option<(String, usize)> {
+        let mut best_match: Option<(String, usize)> = None;
+
+        for name in self.descriptors.keys() {
+            let descriptor_segments: Vec<&str> = name.split(':').collect();
+            if descriptor_segments.len() > path_segments.len() {
+                continue;
+            }
+
+            if descriptor_segments
+                .iter()
+                .zip(path_segments.iter())
+                .all(|(expected, actual)| expected == actual)
+            {
+                match &best_match {
+                    Some((_, best_len)) if *best_len >= descriptor_segments.len() => {}
+                    _ => best_match = Some((name.clone(), descriptor_segments.len())),
+                }
+            }
+        }
+
+        best_match
+    }
+
+    /// Add a default value to a special category descriptor.
+    ///
+    /// Static categories are updated immediately to mirror upstream behavior.
+    pub fn add_default_value(
+        &mut self,
+        category_name: &str,
+        property: String,
+        default_value: ConfigValue,
+    ) -> ParseResult<()> {
+        let is_static = {
+            let descriptor = self
+                .descriptors
+                .get_mut(category_name)
+                .ok_or_else(|| ConfigError::category_not_found(category_name, None))?;
+            descriptor
+                .default_values
+                .insert(property.clone(), default_value.clone());
+            descriptor.category_type == SpecialCategoryType::Static
+        };
+
+        if is_static {
+            let instance_key = self.create_instance(category_name, None)?;
+            if let Ok(instance) = self.get_instance_mut(category_name, &instance_key) {
+                instance.set(property, ConfigValueEntry::with_default(default_value));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Remove a default value from a special category descriptor and all existing instances.
+    pub fn remove_default_value(&mut self, category_name: &str, property: &str) -> ParseResult<()> {
+        let descriptor = self
+            .descriptors
+            .get_mut(category_name)
+            .ok_or_else(|| ConfigError::category_not_found(category_name, None))?;
+        descriptor.default_values.remove(property);
+
+        if let Some(instances) = self.instances.get_mut(category_name) {
+            for instance in instances.values_mut() {
+                instance.values.remove(property);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Remove a registered special category and all instances.
+    pub fn remove_category(&mut self, category_name: &str) {
+        self.descriptors.remove(category_name);
+        self.instances.remove(category_name);
+    }
+
+    /// Reset instances to their pre-parse state.
+    ///
+    /// Static categories keep a static instance populated from defaults. Keyed and anonymous
+    /// categories are cleared completely.
+    pub fn reset_for_parse(&mut self) {
+        self.next_anonymous_key = 1;
+
+        let descriptors: Vec<_> = self.descriptors.values().cloned().collect();
         self.instances.clear();
-        self.anonymous_counters.clear();
+
+        for descriptor in descriptors {
+            if descriptor.category_type != SpecialCategoryType::Static {
+                continue;
+            }
+
+            let mut instance = SpecialCategoryInstance::new(Some("static".to_string()));
+            for (prop_name, default_value) in descriptor.default_values {
+                instance.set(prop_name, ConfigValueEntry::with_default(default_value));
+            }
+
+            self.instances
+                .entry(descriptor.name)
+                .or_default()
+                .insert("static".to_string(), instance);
+        }
     }
 }
 
@@ -383,9 +529,9 @@ mod tests {
         let key2 = manager.create_instance("item", None).unwrap();
         let key3 = manager.create_instance("item", None).unwrap();
 
-        assert_eq!(key1, "anonymous_0");
-        assert_eq!(key2, "anonymous_1");
-        assert_eq!(key3, "anonymous_2");
+        assert_eq!(key1, "1");
+        assert_eq!(key2, "2");
+        assert_eq!(key3, "3");
     }
 
     #[test]

--- a/tests/expression_escaping_test.rs
+++ b/tests/expression_escaping_test.rs
@@ -46,7 +46,7 @@ fn test_mixed_escaped_and_eval() {
     // First expression evaluates, second is literal
     assert_eq!(
         config.get_string("testValue").unwrap(),
-        "-2 and {{literal}}"
+        "\"-2 and {{literal}}\""
     );
 }
 
@@ -76,7 +76,7 @@ fn test_complex_mixed_escapes() {
     // First expression evaluates, escaped part stays literal
     assert_eq!(
         config.get_string("testValue").unwrap(),
-        "-2 {{ literal }} more"
+        "\"-2 {{ literal }} more\""
     );
 }
 
@@ -141,16 +141,16 @@ fn test_config_file_escapes() {
 
     assert_eq!(
         config.get_string("testEscapedExpr").unwrap(),
-        "{{testInt + 7}}"
+        "\"{{testInt + 7}}\""
     );
     assert_eq!(
         config.get_string("testEscapedExpr2").unwrap(),
-        "{{testInt + 7}}"
+        "\"{{testInt + 7}}\""
     );
-    assert_eq!(config.get_string("testEscapedExpr3").unwrap(), "{{3 + 8}}");
-    assert_eq!(config.get_string("testEscapedEscape").unwrap(), r"\5");
+    assert_eq!(config.get_string("testEscapedExpr3").unwrap(), "\"{{3 + 8}}\"");
+    assert_eq!(config.get_string("testEscapedEscape").unwrap(), r#""\5""#);
     assert_eq!(
         config.get_string("testSimpleMix").unwrap(),
-        "-2 and {{ literal }}"
+        "\"-2 and {{ literal }}\""
     );
 }

--- a/tests/mutation_test.rs
+++ b/tests/mutation_test.rs
@@ -2,6 +2,15 @@
 
 use hyprlang::{Config, ConfigValue};
 
+fn register_device_category(config: &mut Config) {
+    use hyprlang::SpecialCategoryDescriptor;
+
+    config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+    config.register_special_category_value("device", "sensitivity", ConfigValue::Float(0.0));
+    config.register_special_category_value("device", "repeat_rate", ConfigValue::Int(0));
+    config.register_special_category_value("device", "tap_to_click", ConfigValue::Int(0));
+}
+
 #[test]
 fn test_serialize_synthetic() {
     let mut config = Config::new();
@@ -183,11 +192,9 @@ key = value1
 
 #[test]
 fn test_round_trip_with_all_types() {
-    use hyprlang::SpecialCategoryDescriptor;
-
     let mut config1 = Config::new();
     config1.register_handler_fn("bind", |_ctx| Ok(()));
-    config1.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+    register_device_category(&mut config1);
 
     config1
         .parse(
@@ -209,7 +216,7 @@ device[mouse] {
 
     let mut config2 = Config::new();
     config2.register_handler_fn("bind", |_ctx| Ok(()));
-    config2.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+    register_device_category(&mut config2);
     config2.parse(&serialized).unwrap();
 
     // Verify all values preserved
@@ -264,10 +271,8 @@ bind = SUPER, C, exec, editor
 
 #[test]
 fn test_round_trip_after_special_category_removal() {
-    use hyprlang::SpecialCategoryDescriptor;
-
     let mut config = Config::new();
-    config.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+    register_device_category(&mut config);
 
     config
         .parse(
@@ -294,7 +299,7 @@ device[touchpad] {
     let serialized = config.serialize();
 
     let mut config2 = Config::new();
-    config2.register_special_category(SpecialCategoryDescriptor::keyed("device", "name"));
+    register_device_category(&mut config2);
     config2.parse(&serialized).unwrap();
 
     // Verify mouse and touchpad exist, keyboard doesn't

--- a/tests/parsing_edge_cases_test.rs
+++ b/tests/parsing_edge_cases_test.rs
@@ -1,4 +1,4 @@
-//! Edge case tests for parsing color and Vec2 values.
+//! Edge case tests for parsing color, Vec2, and comment values.
 
 use hyprlang::Config;
 
@@ -124,16 +124,34 @@ fn test_vec2_whitespace_variations() {
     let mut config = Config::new();
 
     // Various whitespace
-    config.parse("size1 = 100,200").unwrap();
-    config.parse("size2 = 100, 200").unwrap();
-    config.parse("size3 = 100 , 200").unwrap();
-    config.parse("size4 =   100  ,  200  ").unwrap();
+    config
+        .parse(
+            r#"
+            size1 = 100,200
+            size2 = 100, 200
+            size3 = 100 , 200
+            size4 =   100  ,  200
+        "#,
+        )
+        .unwrap();
 
     // All should parse as valid vec2
     assert!(config.get_vec2("size1").is_ok());
     assert!(config.get_vec2("size2").is_ok());
     assert!(config.get_vec2("size3").is_ok());
     assert!(config.get_vec2("size4").is_ok());
+}
+
+#[test]
+fn test_top_level_parse_resets_state() {
+    let mut config = Config::new();
+
+    config.parse("first = 1").unwrap();
+    assert_eq!(config.get_int("first").unwrap(), 1);
+
+    config.parse("second = 2").unwrap();
+    assert!(config.get("first").is_err());
+    assert_eq!(config.get_int("second").unwrap(), 2);
 }
 
 #[test]
@@ -173,6 +191,85 @@ fn test_vec2_extra_components_ignored() {
     let value = config.get("size").unwrap();
     // Behavior depends on implementation
     let _ = value.as_vec2();
+}
+
+// ========== COMMENT ESCAPING EDGE CASES ==========
+
+#[test]
+fn test_comment_escape_basic() {
+    let mut config = Config::new();
+    config
+        .parse("testString = Hello World! ## This is not a comment! # This is!")
+        .unwrap();
+    assert_eq!(
+        config.get_string("testString").unwrap(),
+        "Hello World! # This is not a comment!"
+    );
+}
+
+#[test]
+fn test_comment_escape_double_hash_only() {
+    let mut config = Config::new();
+    config.parse("key = value ## text").unwrap();
+    assert_eq!(config.get_string("key").unwrap(), "value # text");
+}
+
+#[test]
+fn test_comment_escape_multiple_double_hashes() {
+    let mut config = Config::new();
+    config.parse("key = a ## b ## c").unwrap();
+    assert_eq!(config.get_string("key").unwrap(), "a # b # c");
+}
+
+#[test]
+fn test_comment_escape_quadruple_hash() {
+    let mut config = Config::new();
+    config.parse("key = value ####").unwrap();
+    assert_eq!(config.get_string("key").unwrap(), "value ##");
+}
+
+#[test]
+fn test_comment_escape_triple_hash() {
+    // ### = ## (escaped) + # (comment start) -> value is single #
+    let mut config = Config::new();
+    config.parse("key = value ###").unwrap();
+    assert_eq!(config.get_string("key").unwrap(), "value #");
+}
+
+#[test]
+fn test_comment_escape_no_hash() {
+    let mut config = Config::new();
+    config.parse("key = normal value").unwrap();
+    assert_eq!(config.get_string("key").unwrap(), "normal value");
+}
+
+#[test]
+fn test_comment_escape_single_hash_comment() {
+    let mut config = Config::new();
+    config.parse("key = value # comment").unwrap();
+    assert_eq!(config.get_string("key").unwrap(), "value");
+}
+
+#[test]
+fn test_comment_escape_in_quoted_string() {
+    // ## inside quotes should be preserved as-is
+    let mut config = Config::new();
+    config.parse(r#"key = "value ## text""#).unwrap();
+    assert_eq!(config.get_string("key").unwrap(), "\"value ## text\"");
+}
+
+#[test]
+fn test_comment_escape_with_variable() {
+    let mut config = Config::new();
+    config
+        .parse(
+            r#"
+        $VAR = world
+        key = hello $VAR ## escaped
+    "#,
+        )
+        .unwrap();
+    assert_eq!(config.get_string("key").unwrap(), "hello world # escaped");
 }
 
 // ========== GENERAL PARSING EDGE CASES ==========

--- a/tests/windowrule_v3_test.rs
+++ b/tests/windowrule_v3_test.rs
@@ -195,6 +195,30 @@ fn test_mixed_v2_and_v3_syntax() {
 }
 
 #[test]
+fn test_windowrule_bracketless_syntax() {
+    let mut hypr = Hyprland::new();
+
+    // Bracketless syntax: key resolved from `name = ...` inside the block
+    hypr.parse(
+        r#"
+        windowrule {
+            name = magnifier
+            match:title = ^(Magnifier)$
+            float = yes
+        }
+    "#,
+    )
+    .unwrap();
+
+    let names = hypr.windowrule_names();
+    assert!(names.contains(&"magnifier".to_string()));
+
+    let rule = hypr.get_windowrule("magnifier").unwrap();
+    assert_eq!(rule.get_string("match:title").unwrap(), "^(Magnifier)$");
+    assert_eq!(rule.get_int("float").unwrap(), 1); // "yes" -> true -> 1
+}
+
+#[test]
 fn test_windowrule_not_found() {
     let hypr = Hyprland::new();
 


### PR DESCRIPTION
## PR Summary: Hyprlang Parity Update (v0.6.8)

This pull request brings **hyprlang-rs** into full parity with the latest reference **hyprlang** behavior (v0.6.8). It addresses several core parsing inconsistencies, refines category handling, and updates Hyprland-side logic to maintain compatibility with stricter schema validation.



### Key Changes

(Core) Parser Refinements

* **Parsing Fixes:** Improved quoted-string parsing and top-level parse reset semantics.
* **Handler Logic:** Fixed flagged handler dispatch and resolved name collisions between handlers and special categories.
* **Variable Management:** Implemented dynamic variable replay deduplication and corrected `change_root_path()` source resolution.

#### Special-Category & Schema Validation

* **Strict Alignment:** Tightened special-category handling to match upstream validation for declared properties.
* **Block Requirements:** Keyed bracketless blocks now require the key to be set first.
* **Routing:** Corrected routing for nested special-category paths and added support for explicit keys in anonymous dynamic categories.

#### Hyprland Integration

* **Polymorphic Rules:** Updated `windowrule` and `layerrule` handling. String-backed fields can now be read as `int`, `float`, or `color` to ensure functional parity under stricter validation.
* **Documentation & Examples:** Refreshed mutation logic and examples to explicitly register special-category properties.


### Testing & Quality Assurance

* **Regression Coverage:** Added new test cases covering the parity gaps identified during review.
* **Validation Suite:**
* `cargo test`
* `cargo test --all-features`
